### PR TITLE
Migrate maze/pathfinding services to javafx.concurrent.Worker + fix grid centering

### DIFF
--- a/src/main/java/org/mahefa/component/Grid.java
+++ b/src/main/java/org/mahefa/component/Grid.java
@@ -29,9 +29,11 @@ public class Grid {
         colLen = ((int) Math.ceil(canvasWidth / gridSize) / 2) * 2 - 1;
         cells = new Cell[rowLen][colLen];
 
-        // Calculate padding
-        double paddingY = Math.abs((colLen * gridSize) - canvasWidth) / 2;
-        double paddingX = Math.abs((rowLen * gridSize) - canvasHeight) / 2;
+        // Center the grid within the canvas: split the leftover space evenly on each
+        // side. Signed (not Math.abs) so the margins stay equal even when rounding makes
+        // the grid slightly wider than the canvas — otherwise the gap flips to one side.
+        double paddingY = (canvasWidth - (colLen * gridSize)) / 2;
+        double paddingX = (canvasHeight - (rowLen * gridSize)) / 2;
 
         // Default start and target cell position
         startRow = (int) Math.ceil(rowLen / 2d);

--- a/src/main/java/org/mahefa/controller/MainWindowController.java
+++ b/src/main/java/org/mahefa/controller/MainWindowController.java
@@ -146,13 +146,11 @@ public class MainWindowController {
     }
 
     private Grid buildGrid(double width, double height) {
-        double defaultPadding = 5.0;
-
         // Clear existing grid
         gridPane.getChildren().clear();
 
-        // Create a grid
-        Grid grid = new Grid(width + defaultPadding, height + defaultPadding, gridSize, (currentCell) -> {
+        // Create a grid sized to the actual pane, so the grid centers with equal margins
+        Grid grid = new Grid(width, height, gridSize, (currentCell) -> {
             if (currentCell.isSpecialNode()) {
                 NodeType currentNodeType = currentCell.getNodeType();
 
@@ -289,8 +287,10 @@ public class MainWindowController {
         if (gridService == null)
             throw new PathFindingException("Service not instantiated properly");
 
-        gridService.getMazeService().setAlgorithm(MazeAlgorithm.valueOf(algorithm));
-        gridService.getMazeService().run();
+//        gridService.getMazeService().setAlgorithm(MazeAlgorithm.valueOf(algorithm));
+//        gridService.getMazeService().run();
+        gridService.getMazeGeneratorWorker().setAlgorithm(MazeAlgorithm.valueOf(algorithm));
+        gridService.getMazeGeneratorWorker().start();
 
         // Release
         currentMenu.selectedItemProperty().setValue(null);
@@ -344,7 +344,8 @@ public class MainWindowController {
         btnPlay.getLabel().setText(btnTxtArg + "!");
 
         // Update service
-        gridService.getRouteFinderService().setAlgorithm(algorithm);
+//        gridService.getRouteFinderService().setAlgorithm(algorithm);
+        gridService.getPathfindingWorker().setAlgorithm(algorithm);
     }
 
     private void menuAction(Menu currentMenu) {
@@ -366,7 +367,8 @@ public class MainWindowController {
     private void execute() {
         try {
             if (gridService.isReady()) {
-                gridService.getRouteFinderService().run();
+//                gridService.getRouteFinderService().run();
+                gridService.getPathfindingWorker().start();
             }
         } catch (Exception e) {
             if (e instanceof MissingAlgorithmException) {
@@ -376,7 +378,8 @@ public class MainWindowController {
                 LOGGER.error(e.getMessage(), e);
             }
 
-            gridService.setCurrentState(ServiceState.FAILED);
+//            gridService.setCurrentState(ServiceState.FAILED);
+            gridService.cancelRunningWorkers();
         }
     }
 }

--- a/src/main/java/org/mahefa/service/GridService.java
+++ b/src/main/java/org/mahefa/service/GridService.java
@@ -4,10 +4,11 @@ import javafx.beans.binding.Bindings;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 import org.mahefa.common.enumerator.AnimationSpeed;
-import org.mahefa.common.enumerator.MazeGenerationAnimationSpeed;
 import org.mahefa.common.enumerator.LaunchAnimationSpeed;
-import org.mahefa.common.enumerator.ServiceState;
+import org.mahefa.common.enumerator.MazeGenerationAnimationSpeed;
 import org.mahefa.component.Grid;
+import org.mahefa.service.concurrent.MazeGeneratorWorker;
+import org.mahefa.service.concurrent.PathfindingWorker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -18,20 +19,30 @@ public class GridService {
     private static final Logger LOGGER = LoggerFactory.getLogger(GridService.class);
 
     protected Grid grid;
-    private MazeService mazeService;
-    private RouteFinderService routeFinderService;
+//    private MazeService mazeService;
+//    private RouteFinderService routeFinderService;
+    private MazeGeneratorWorker mazeGeneratorWorker;
+    private PathfindingWorker pathfindingWorker;
 
     private BooleanProperty isReady = new SimpleBooleanProperty(false);
 
     public GridService(Grid grid) {
         this.grid = grid;
-        this.mazeService = new MazeService(grid);
-        this.routeFinderService = new RouteFinderService(grid);
+//        this.mazeService = new MazeService(grid);
+//        this.routeFinderService = new RouteFinderService(grid);
+        this.mazeGeneratorWorker = new MazeGeneratorWorker(grid);
+        this.pathfindingWorker = new PathfindingWorker(grid);
 
+//        isReady.bind(
+//                Bindings.and(
+//                        mazeService.currentStateProperty().isEqualTo(ServiceState.IDLE),
+//                        routeFinderService.currentStateProperty().isEqualTo(ServiceState.IDLE)
+//                )
+//        );
         isReady.bind(
                 Bindings.and(
-                        mazeService.currentStateProperty().isEqualTo(ServiceState.IDLE),
-                        routeFinderService.currentStateProperty().isEqualTo(ServiceState.IDLE)
+                        mazeGeneratorWorker.runningProperty().not(),
+                        pathfindingWorker.runningProperty().not()
                 )
         );
     }
@@ -40,12 +51,20 @@ public class GridService {
         return grid;
     }
 
-    public MazeService getMazeService() {
-        return mazeService;
+//    public MazeService getMazeService() {
+//        return mazeService;
+//    }
+//
+//    public RouteFinderService getRouteFinderService() {
+//        return routeFinderService;
+//    }
+
+    public MazeGeneratorWorker getMazeGeneratorWorker() {
+        return mazeGeneratorWorker;
     }
 
-    public RouteFinderService getRouteFinderService() {
-        return routeFinderService;
+    public PathfindingWorker getPathfindingWorker() {
+        return pathfindingWorker;
     }
 
     public boolean isReady() {
@@ -60,14 +79,30 @@ public class GridService {
         this.isReady.set(isReady);
     }
 
-    public void setCurrentState(ServiceState currentState) {
-        mazeService.setCurrentState(currentState);
-        routeFinderService.setCurrentState(currentState);
+//    public void setCurrentState(ServiceState currentState) {
+//        mazeService.setCurrentState(currentState);
+//        routeFinderService.setCurrentState(currentState);
+//    }
+
+    /**
+     * Cancels both workers if they're running. Used to recover from an exception raised
+     * before either worker's AnimationTimer ever started (e.g. no algorithm selected yet).
+     */
+    public void cancelRunningWorkers() {
+        if (mazeGeneratorWorker.isRunning()) {
+            mazeGeneratorWorker.cancel();
+        }
+
+        if (pathfindingWorker.isRunning()) {
+            pathfindingWorker.cancel();
+        }
     }
 
     public void updateSpeed(AnimationSpeed currentSpeed) {
-        getMazeService().updateSpeed(MazeGenerationAnimationSpeed.valueOf(currentSpeed.name()).getInterval());
-        getRouteFinderService().updateSpeed(LaunchAnimationSpeed.valueOf(currentSpeed.name()).getInterval());
+//        getMazeService().updateSpeed(MazeGenerationAnimationSpeed.valueOf(currentSpeed.name()).getInterval());
+//        getRouteFinderService().updateSpeed(LaunchAnimationSpeed.valueOf(currentSpeed.name()).getInterval());
+        getMazeGeneratorWorker().setCurrentSpeed(MazeGenerationAnimationSpeed.valueOf(currentSpeed.name()).getInterval());
+        getPathfindingWorker().setCurrentSpeed(LaunchAnimationSpeed.valueOf(currentSpeed.name()).getInterval());
     }
 
     public void clearBoard() {
@@ -86,8 +121,9 @@ public class GridService {
     }
 
     private void clear(boolean reset, boolean removeWalls) {
-        mazeService.currentStateProperty().setValue(ServiceState.STOPPING);
-        routeFinderService.currentStateProperty().setValue(ServiceState.STOPPING);
+//        mazeService.currentStateProperty().setValue(ServiceState.STOPPING);
+//        routeFinderService.currentStateProperty().setValue(ServiceState.STOPPING);
+        cancelRunningWorkers();
 
         if (grid != null) {
             grid.setDefaultFlag(NONE);

--- a/src/main/java/org/mahefa/service/concurrent/AnimationWorker.java
+++ b/src/main/java/org/mahefa/service/concurrent/AnimationWorker.java
@@ -1,0 +1,215 @@
+package org.mahefa.service.concurrent;
+
+import javafx.animation.AnimationTimer;
+import javafx.beans.property.*;
+import javafx.beans.value.ChangeListener;
+import javafx.concurrent.Worker;
+
+import java.util.function.Supplier;
+
+/**
+ * A {@link Worker} implementation for work that must run on the FX Application Thread
+ * (e.g. per-frame mutation of scene graph {@code Node}s), rather than on a background
+ * thread as {@link javafx.concurrent.Task}/{@link javafx.concurrent.Service} expect.
+ * <p>
+ * Subclasses drive an {@link AnimationTimer} via {@link #begin(Supplier, ReadOnlyBooleanProperty, Object)}
+ * and get the standard {@link Worker.State} lifecycle and bindable properties in return.
+ * <p>
+ * {@code begin(...)} is deliberately not named {@code start()}: concrete subclasses expose their
+ * own public no-arg {@code start()} (which builds their solver/generator, then calls {@code begin(...)}
+ * to hand the resulting timer to this class) — naming both "start" would make the two easy to
+ * confuse despite being unrelated overloads.
+ */
+public abstract class AnimationWorker<T> implements Worker<T> {
+
+    private final ReadOnlyObjectWrapper<State> state = new ReadOnlyObjectWrapper<>(this, "state", State.READY);
+    private final ReadOnlyBooleanWrapper running = new ReadOnlyBooleanWrapper(this, "running", false);
+    private final ReadOnlyObjectWrapper<T> value = new ReadOnlyObjectWrapper<>(this, "value");
+    private final ReadOnlyObjectWrapper<Throwable> exception = new ReadOnlyObjectWrapper<>(this, "exception");
+    private final ReadOnlyStringWrapper message = new ReadOnlyStringWrapper(this, "message", "");
+    private final ReadOnlyStringWrapper title = new ReadOnlyStringWrapper(this, "title", "");
+    private final ReadOnlyDoubleWrapper progress = new ReadOnlyDoubleWrapper(this, "progress", -1);
+    private final ReadOnlyDoubleWrapper totalWork = new ReadOnlyDoubleWrapper(this, "totalWork", -1);
+    private final ReadOnlyDoubleWrapper workDone = new ReadOnlyDoubleWrapper(this, "workDone", -1);
+    private final ObjectProperty<Long> currentSpeed = new SimpleObjectProperty<>();
+
+    private AnimationTimer animationTimer;
+    private ReadOnlyBooleanProperty completionSignal;
+    private ChangeListener<Boolean> completionListener;
+
+    protected AnimationWorker() {
+        currentSpeed.addListener((observable, oldSpeed, newSpeed) -> onSpeedChanged(newSpeed));
+    }
+
+    public void setCurrentSpeed(Long speed) {
+        currentSpeed.setValue(speed);
+    }
+
+    public Long getCurrentSpeed() {
+        return currentSpeed.get();
+    }
+
+    /**
+     * Called whenever {@link #setCurrentSpeed(Long)} changes the speed, including while running.
+     * No-op by default; subclasses override to forward the new speed to their underlying
+     * solver/generator, since only they know which instance is currently active.
+     */
+    protected void onSpeedChanged(Long speed) {
+    }
+
+    /**
+     * Starts the given {@link AnimationTimer} on the FX Application Thread and transitions
+     * through {@code SCHEDULED -> RUNNING}. When {@code completionSignal} flips from
+     * {@code true} to {@code false}, the timer is stopped, {@code completionValue} becomes
+     * this worker's {@link #getValue()}, and the state transitions to {@code SUCCEEDED}.
+     */
+    protected final void begin(Supplier<AnimationTimer> timerSupplier, ReadOnlyBooleanProperty completionSignal, T completionValue) {
+        if (getState() == State.RUNNING || getState() == State.SCHEDULED) {
+            throw new IllegalStateException("AnimationWorker is already running");
+        }
+
+        setState(State.SCHEDULED);
+
+        this.completionSignal = completionSignal;
+        this.completionListener = (observable, wasRunning, isRunning) -> {
+            if (wasRunning && !isRunning) {
+                onCompleted(completionValue);
+            }
+        };
+        completionSignal.addListener(completionListener);
+
+        animationTimer = timerSupplier.get();
+        setState(State.RUNNING);
+        animationTimer.start();
+    }
+
+    private void onCompleted(T completionValue) {
+        if (getState() != State.RUNNING) {
+            return;
+        }
+
+        stopTimer();
+        value.set(completionValue);
+        setState(State.SUCCEEDED);
+    }
+
+    @Override
+    public boolean cancel() {
+        if (getState() != State.RUNNING && getState() != State.SCHEDULED) {
+            return false;
+        }
+
+        stopTimer();
+        setState(State.CANCELLED);
+        return true;
+    }
+
+    private void stopTimer() {
+        if (animationTimer != null) {
+            animationTimer.stop();
+        }
+
+        if (completionSignal != null && completionListener != null) {
+            completionSignal.removeListener(completionListener);
+        }
+    }
+
+    private void setState(State newState) {
+        state.set(newState);
+        running.set(newState == State.RUNNING);
+    }
+
+    protected void setException(Throwable throwable) {
+        exception.set(throwable);
+    }
+
+    @Override
+    public State getState() {
+        return state.get();
+    }
+
+    @Override
+    public ReadOnlyObjectProperty<State> stateProperty() {
+        return state.getReadOnlyProperty();
+    }
+
+    @Override
+    public T getValue() {
+        return value.get();
+    }
+
+    @Override
+    public ReadOnlyObjectProperty<T> valueProperty() {
+        return value.getReadOnlyProperty();
+    }
+
+    @Override
+    public Throwable getException() {
+        return exception.get();
+    }
+
+    @Override
+    public ReadOnlyObjectProperty<Throwable> exceptionProperty() {
+        return exception.getReadOnlyProperty();
+    }
+
+    @Override
+    public double getWorkDone() {
+        return workDone.get();
+    }
+
+    @Override
+    public ReadOnlyDoubleProperty workDoneProperty() {
+        return workDone.getReadOnlyProperty();
+    }
+
+    @Override
+    public double getTotalWork() {
+        return totalWork.get();
+    }
+
+    @Override
+    public ReadOnlyDoubleProperty totalWorkProperty() {
+        return totalWork.getReadOnlyProperty();
+    }
+
+    @Override
+    public double getProgress() {
+        return progress.get();
+    }
+
+    @Override
+    public ReadOnlyDoubleProperty progressProperty() {
+        return progress.getReadOnlyProperty();
+    }
+
+    @Override
+    public boolean isRunning() {
+        return running.get();
+    }
+
+    @Override
+    public ReadOnlyBooleanProperty runningProperty() {
+        return running.getReadOnlyProperty();
+    }
+
+    @Override
+    public String getMessage() {
+        return message.get();
+    }
+
+    @Override
+    public ReadOnlyStringProperty messageProperty() {
+        return message.getReadOnlyProperty();
+    }
+
+    @Override
+    public String getTitle() {
+        return title.get();
+    }
+
+    @Override
+    public ReadOnlyStringProperty titleProperty() {
+        return title.getReadOnlyProperty();
+    }
+}

--- a/src/main/java/org/mahefa/service/concurrent/MazeGeneratorWorker.java
+++ b/src/main/java/org/mahefa/service/concurrent/MazeGeneratorWorker.java
@@ -1,0 +1,77 @@
+package org.mahefa.service.concurrent;
+
+import javafx.animation.AnimationTimer;
+import org.mahefa.common.enumerator.MazeAlgorithm;
+import org.mahefa.common.exceptions.UnsupportedAlgorithmException;
+import org.mahefa.component.Grid;
+import org.mahefa.service.maze_generator.AldousBroder;
+import org.mahefa.service.maze_generator.MazeGenerator;
+import org.mahefa.service.maze_generator.Randomized;
+
+import java.util.function.Supplier;
+
+import static org.mahefa.common.CellStyle.Flag.NONE;
+import static org.mahefa.common.CellStyle.Flag.WALL_NODE;
+
+/**
+ * {@link javafx.concurrent.Worker}-based equivalent of {@link org.mahefa.service.MazeService},
+ * reusing the existing {@link MazeGenerator} implementations unchanged.
+ */
+public class MazeGeneratorWorker extends AnimationWorker<MazeGenerator> {
+
+    private final Grid grid;
+
+    private MazeAlgorithm algorithm;
+    private MazeGenerator mazeGenerator;
+
+    public MazeGeneratorWorker(Grid grid) {
+        this.grid = grid;
+    }
+
+    public void setAlgorithm(MazeAlgorithm algorithm) {
+        this.algorithm = algorithm;
+    }
+
+    public MazeGenerator getMazeGenerator() {
+        return mazeGenerator;
+    }
+
+    @Override
+    protected void onSpeedChanged(Long speed) {
+        if (mazeGenerator != null && speed != null) {
+            mazeGenerator.setCurrentSpeed(speed);
+        }
+    }
+
+    public void start() {
+        if (algorithm == null) {
+            return;
+        }
+
+        if (isRunning()) {
+            cancel();
+        }
+
+        switch (algorithm) {
+            case ALDOUS_BRODER:
+                grid.setDefaultFlag(WALL_NODE);
+                mazeGenerator = new AldousBroder(grid);
+                mazeGenerator.setCurrentSpeed(getCurrentSpeed());
+                break;
+            case BASIC_RANDOM:
+                grid.setDefaultFlag(NONE);
+                mazeGenerator = new Randomized(grid);
+                break;
+            default:
+                throw new UnsupportedAlgorithmException("Unsupported algorithm: " + algorithm);
+        }
+
+        grid.clear(true, false, false);
+
+        Supplier<AnimationTimer> animationTimerSupplier = mazeGenerator.build();
+
+        if (animationTimerSupplier != null) {
+            begin(animationTimerSupplier, mazeGenerator.isRunningProperty(), mazeGenerator);
+        }
+    }
+}

--- a/src/main/java/org/mahefa/service/concurrent/PathfindingWorker.java
+++ b/src/main/java/org/mahefa/service/concurrent/PathfindingWorker.java
@@ -1,0 +1,65 @@
+package org.mahefa.service.concurrent;
+
+import org.mahefa.common.enumerator.PathFindingAlgorithm;
+import org.mahefa.common.exceptions.MissingAlgorithmException;
+import org.mahefa.common.exceptions.UnsupportedAlgorithmException;
+import org.mahefa.component.Grid;
+import org.mahefa.service.pathfinding.AStar;
+import org.mahefa.service.pathfinding.Solver;
+
+/**
+ * {@link javafx.concurrent.Worker}-based equivalent of {@link org.mahefa.service.RouteFinderService},
+ * reusing the existing {@link Solver}/{@link AStar} implementations unchanged.
+ */
+public class PathfindingWorker extends AnimationWorker<Solver> {
+
+    private final Grid grid;
+
+    private PathFindingAlgorithm algorithm;
+    private Solver solver;
+
+    public PathfindingWorker(Grid grid) {
+        this.grid = grid;
+    }
+
+    public void setAlgorithm(PathFindingAlgorithm algorithm) {
+        this.algorithm = algorithm;
+    }
+
+    public Solver getSolver() {
+        return solver;
+    }
+
+    @Override
+    protected void onSpeedChanged(Long speed) {
+        if (solver != null) {
+            solver.setCurrentSpeed(speed);
+        }
+    }
+
+    public void start() {
+        if (algorithm == null) {
+            throw new MissingAlgorithmException("Pick an Algorithm!");
+        }
+
+        if (isRunning()) {
+            cancel();
+        }
+
+        switch (algorithm) {
+            case A_STAR:
+                solver = new AStar(grid);
+                break;
+            case DIJKSTRA:
+            case BREADTH_FIRST_SEARCH:
+            case DEPTH_FIRST_SEARCH:
+            default:
+                throw new UnsupportedAlgorithmException("Unsupported algorithm: " + algorithm);
+        }
+
+        grid.clear(false, false, false);
+        solver.setCurrentSpeed(getCurrentSpeed());
+
+        begin(solver.solve(), solver.isRunningProperty(), solver);
+    }
+}


### PR DESCRIPTION
Closes #15.

## What

Replaces the hand-rolled `AnimatableService`/`ServiceState` orchestration with a `javafx.concurrent.Worker`-based service layer, and fixes the grid horizontal centering.

### New package `org.mahefa.service.concurrent`
- **`AnimationWorker<T>`** — implements `javafx.concurrent.Worker<T>`, driving an `AnimationTimer` on the FX Application Thread. Exposes the standard `READY → SCHEDULED → RUNNING → SUCCEEDED/CANCELLED` lifecycle, bindable `state`/`running`/`value`, `cancel()`, and a `setCurrentSpeed(...)`/`onSpeedChanged(...)` hook for live speed changes. (A background `Task`/`Service` isn't a fit — the per-step work mutates `Cell` nodes on the FX thread every frame — so `Worker` is implemented directly while keeping the `AnimationTimer` model.)
- **`PathfindingWorker`** — `RouteFinderService` equivalent; reuses `AStar`/`Solver` unchanged.
- **`MazeGeneratorWorker`** — `MazeService` equivalent; reuses `AldousBroder`/`MazeGenerator` unchanged.

### Wiring
- `GridService` and `MainWindowController` route Play + maze menus through the workers; `isReady` binds to `runningProperty().not()`.
- Old `RouteFinderService`/`MazeService` paths are **commented out, not deleted** (project still in progress).

### Grid centering
- `Grid` uses signed centering padding and `MainWindowController` drops the `+5` canvas inflation, so the grid centers with equal left/right margins. Previously the gap was consistently left-heavy and occasionally flipped to the right depending on window width.

## Why

The old services reimplemented `Worker.State` by hand: a custom `ServiceState` enum, a side-channel `isRunningProperty()` completion listener duplicated across both services, `synchronized` on FX-thread-only code, a leftover console-spinner `Timeline`, and a premature-completion bug (fixed earlier in `2ac7b0f`) that was a direct symptom of the hand-rolled state machine.

## Testing

- `mvn compile` clean (52 sources).
- Headless lifecycle checks: A* and maze workers go `READY → SCHEDULED → RUNNING → SUCCEEDED`; `cancel()` mid-run → `CANCELLED` and stops the timer; FAST/AVERAGE/SLOW speed changes take effect on the running worker.
- Grid margins verified symmetric across a range of window widths.
- Manually exercised in the running app (A* visualize, Aldous-Broder generate, speed change mid-run, clear board).

## Not in this PR

- **Minor:** vertical grid centering — `paddingX` is computed but not applied to the cell's vertical position (one-line follow-up).
- **Minor (pre-existing):** `GridUtils.pickRandomCell` crashes on a 3×3 grid (`nextInt(0)`); tracked separately.
- `AldousBroder` start/target endpoint experiments were reverted — out of scope here.

## Base

Targets `11-cell-animation` so the diff is only this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
