### PR TITLE
Migrate to JavaFX 23 + Spring Boot 3.5.0 (infra) [1/2]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.1.3.RELEASE</version>
+    <version>3.5.0</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
 
@@ -19,11 +19,9 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
+    <java.version>21</java.version>
+    <javafx.version>23</javafx.version>
     <ikonli.version>12.3.1</ikonli.version>
-    <jfoenix.version>9.0.1</jfoenix.version>
-    <animatefx.version>1.2.4</animatefx.version>
   </properties>
 
   <dependencies>
@@ -39,44 +37,31 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.11</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.openjfx</groupId>
       <artifactId>javafx-controls</artifactId>
-      <version>20.0.2</version>
+      <version>${javafx.version}</version>
       <type>pom</type>
     </dependency>
 
     <dependency>
       <groupId>org.openjfx</groupId>
       <artifactId>javafx-media</artifactId>
-      <version>20.0.2</version>
+      <version>${javafx.version}</version>
       <type>pom</type>
     </dependency>
 
     <dependency>
       <groupId>org.openjfx</groupId>
       <artifactId>javafx-graphics</artifactId>
-      <version>20.0.2</version>
+      <version>${javafx.version}</version>
       <type>pom</type>
     </dependency>
 
     <dependency>
       <groupId>org.openjfx</groupId>
       <artifactId>javafx-fxml</artifactId>
-      <version>20.0.2</version>
+      <version>${javafx.version}</version>
       <type>pom</type>
-    </dependency>
-
-    <dependency>
-      <groupId>com.jfoenix</groupId>
-      <artifactId>jfoenix</artifactId>
-      <version>${jfoenix.version}</version>
     </dependency>
 
     <dependency>
@@ -103,6 +88,7 @@
       <version>${ikonli.version}</version>
     </dependency>
 
+    <!-- TODO: removed in the CSS-transition rewrite (PR 2); only used by CellAnimation. -->
     <dependency>
       <groupId>de.schlegel11</groupId>
       <artifactId>jfxanimation</artifactId>
@@ -115,14 +101,11 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.0</version>
         <configuration>
-          <source>11</source>
-          <target>11</target>
+          <!-- Launch via a non-Application class so the JVM's JavaFX launcher guard
+               ("JavaFX runtime components are missing") isn't tripped when JavaFX is on
+               the classpath (forked run and fat-jar alike). -->
+          <mainClass>org.mahefa.Launcher</mainClass>
         </configuration>
       </plugin>
       <plugin>
@@ -155,7 +138,7 @@
           </execution>
         </executions>
         <configuration>
-          <mainClass>org.mahefa.PathFindingFx</mainClass>
+          <mainClass>org.mahefa.Launcher</mainClass>
         </configuration>
       </plugin>
     </plugins>

--- a/src/main/java/org/mahefa/Launcher.java
+++ b/src/main/java/org/mahefa/Launcher.java
@@ -1,0 +1,17 @@
+package org.mahefa;
+
+/**
+ * Entry point that does <strong>not</strong> extend {@link javafx.application.Application}.
+ * <p>
+ * When the JVM's main class extends {@code Application} and the JavaFX modules are on the
+ * classpath (unnamed module) rather than the module path, the launcher aborts with
+ * "JavaFX runtime components are missing, and are required to run this application".
+ * Delegating from a plain class sidesteps that guard, so the app launches identically
+ * whether run via the Spring Boot plugin (forked) or as a packaged fat jar.
+ */
+public class Launcher {
+
+    public static void main(String[] args) {
+        PathFindingFx.main(args);
+    }
+}


### PR DESCRIPTION
Closes #17. **PR 1 of 2** — infra migration only, no behaviour change. The CSS-transition animation rewrite follows in PR 2.

## What
- **JavaFX 20.0.2 → 23** (via a `javafx.version` property); **Java baseline → 21**.
- **Spring Boot parent 2.1.3.RELEASE → 3.5.0** (aligns with scan-2-sheet). Required because the old `spring-boot-maven-plugin` can't read the Java 21 classfiles JavaFX 23 ships as — `Unsupported class file major version 65`.
- **Drop `jfoenix`** — 0 usages in source or FXML.
- **Drop stale explicit `junit` 4.11** (Boot 3 uses JUnit 5 via `starter-test`; no test sources).
- **New `org.mahefa.Launcher`** (does not extend `Application`), set as the `spring-boot` and `exec` plugin `mainClass`. Avoids the "JavaFX runtime components are missing" launcher guard for both the forked dev-run and the packaged fat-jar.
- Drop the redundant explicit `maven-compiler-plugin` source/target (driven by `java.version`).

## jakarta impact
None in source — no `javax.*` imports, no `@PostConstruct`/`@Resource`/`@Inject`. The Spring Boot 3 jump is effectively a pom change here.

## Testing
- `mvn compile` clean.
- App boots via `mvn spring-boot:run` through the launcher on **Spring Boot 3.5.0 / Java 21 / JavaFX 23** — "Started application in 0.76s", UI renders, `ikonli` 12.3.1 FontIcons render, **zero runtime exceptions**. (Only the benign "JavaFX loaded from unnamed module" warning.)
- Behaviour is unchanged: the Worker service layer and the (jfxanimation-based) cell animations are untouched in this PR.

## Follow-ups
- **PR 2:** rewrite `CellAnimation` as CSS `transition:` rules in `cell.scss`, remove `jfxanimation`, and fold in the animation-listener fixes.
- **JavaFX 25 LTS** later — needs JDK 23+, so gated on moving off Java 21.

## Base
Targets `11-cell-animation` (same base as the prior service-layer PR) so the diff is only this migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
