### PR TITLE
Fix 'sun.nio.ch is not open to unnamed module' during the build

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,1 @@
+--add-opens=java.base/sun.nio.ch=ALL-UNNAMED


### PR DESCRIPTION
Closes #19.

## Correction
An earlier version of this PR targeted the app runtime — that was wrong. The error is a **build-time** issue and **pre-existing** (not caused by the JavaFX 23 / Spring Boot upgrade).

## Root cause
`mvn clean install` runs the `sass-maven-plugin` (3.7.2), which compiles SCSS via embedded **JRuby**. JRuby's `FilenoUtil` reflects into `java.base/sun.nio.ch`; on Java 17+ that prints an `IllegalCallerException: sun.nio.ch is not open to unnamed module` + stack trace during `sass:update-stylesheets`. Non-fatal (CSS still compiles), just noisy. It runs in the **Maven JVM**, so the fix opens the package there.

## Fix
Add `.mvn/jvm.config` with `--add-opens=java.base/sun.nio.ch=ALL-UNNAMED`. Maven reads it at JVM startup, so the sass plugin's JRuby can access `sun.nio.ch`. Applies to CLI Maven and IntelliJ's delegated Maven builds.

## Verified
`mvn clean install` → **BUILD SUCCESS**, `FilenoUtil` / `IllegalCallerException` output gone.

Part 1 of 3 follow-ups (logging + cell-animation rewrite are separate PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
