### PR TITLE
Reusable Stepper/StepPlayer pipeline for maze + pathfinding

### DIFF
--- a/src/main/java/com/mahefa/pathfindingfx/algorithm/State.java
+++ b/src/main/java/com/mahefa/pathfindingfx/algorithm/State.java
@@ -3,6 +3,7 @@ package com.mahefa.pathfindingfx.algorithm;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
 
+@Deprecated(forRemoval = true) // superseded by the Stepper/StepPlayer pipeline; kept until removal
 public class State {
 
     protected BooleanProperty isRunning = new SimpleBooleanProperty();

--- a/src/main/java/com/mahefa/pathfindingfx/algorithm/grid/GridModel.java
+++ b/src/main/java/com/mahefa/pathfindingfx/algorithm/grid/GridModel.java
@@ -1,0 +1,60 @@
+package com.mahefa.pathfindingfx.algorithm.grid;
+
+import com.mahefa.pathfindingfx.domain.Location;
+
+/**
+ * A pure, JavaFX-free snapshot of the grid the algorithms run against: dimensions, which cells are
+ * walls, per-cell weight, and the start/target locations. Taken once before a run (by the worker,
+ * which reads the live {@code Grid}), it lets {@link com.mahefa.pathfindingfx.algorithm.step.Stepper}s
+ * stay free of any UI dependency and be unit-tested without a toolkit.
+ */
+public final class GridModel {
+
+    private final int rowLen;
+    private final int colLen;
+    private final boolean[][] wall;
+    private final double[][] weight;
+    private final Location start;
+    private final Location target;
+
+    public GridModel(int rowLen, int colLen, boolean[][] wall, double[][] weight, Location start, Location target) {
+        this.rowLen = rowLen;
+        this.colLen = colLen;
+        this.wall = wall;
+        this.weight = weight;
+        this.start = start;
+        this.target = target;
+    }
+
+    public int getRowLen() {
+        return rowLen;
+    }
+
+    public int getColLen() {
+        return colLen;
+    }
+
+    public Location getStart() {
+        return start;
+    }
+
+    public Location getTarget() {
+        return target;
+    }
+
+    public boolean inBounds(Location location) {
+        return inBounds(location.getRow(), location.getCol());
+    }
+
+    public boolean inBounds(int row, int col) {
+        return row >= 0 && row < rowLen && col >= 0 && col < colLen;
+    }
+
+    public boolean isWall(Location location) {
+        return wall[location.getRow()][location.getCol()];
+    }
+
+    public double weightAt(Location location) {
+        return weight[location.getRow()][location.getCol()];
+    }
+}

--- a/src/main/java/com/mahefa/pathfindingfx/algorithm/grid/Moves.java
+++ b/src/main/java/com/mahefa/pathfindingfx/algorithm/grid/Moves.java
@@ -1,0 +1,90 @@
+package com.mahefa.pathfindingfx.algorithm.grid;
+
+import com.mahefa.pathfindingfx.domain.Cost;
+import com.mahefa.pathfindingfx.domain.Location;
+import com.mahefa.pathfindingfx.domain.enumerator.Direction;
+import com.mahefa.pathfindingfx.domain.enumerator.Rotate;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Pure movement helpers over a {@link GridModel}: the 4-neighbourhood and the turn/step cost used by
+ * A*. Ported from the (UI-coupled) {@code GridUtils} to operate on {@link Location}s only, so the
+ * pathfinding steppers stay JavaFX-free. Logic is unchanged from {@code GridUtils.getCost}.
+ */
+public final class Moves {
+
+    private Moves() {
+    }
+
+    /** In-bounds cardinal neighbours, in the original order (right, up, down, left). */
+    public static List<Location> neighbours(GridModel model, Location location) {
+        List<Location> result = new ArrayList<>(4);
+        Location right = location.move(Direction.RIGHT);
+        Location up = location.move(Direction.UP);
+        Location down = location.move(Direction.DOWN);
+        Location left = location.move(Direction.LEFT);
+
+        if (model.inBounds(right)) result.add(right);
+        if (model.inBounds(up)) result.add(up);
+        if (model.inBounds(down)) result.add(down);
+        if (model.inBounds(left)) result.add(left);
+        return result;
+    }
+
+    /** Step cost + turn sequence to move from {@code current} to {@code neighbour} given the heading. */
+    public static Cost cost(Location current, Location neighbour, Direction currentDirection) {
+        int row1 = current.getRow();
+        int col1 = current.getCol();
+        int row2 = neighbour.getRow();
+        int col2 = neighbour.getCol();
+
+        if (row2 < row1 && col1 == col2) {
+            if (currentDirection.equals(Direction.UP)) {
+                return new Cost(1, Arrays.asList(Rotate.FORWARD), Direction.UP);
+            } else if (currentDirection.equals(Direction.RIGHT)) {
+                return new Cost(2, Arrays.asList(Rotate.LEFT, Rotate.FORWARD), Direction.UP);
+            } else if (currentDirection.equals(Direction.LEFT)) {
+                return new Cost(2, Arrays.asList(Rotate.RIGHT, Rotate.FORWARD), Direction.UP);
+            } else if (currentDirection.equals(Direction.DOWN)) {
+                return new Cost(3, Arrays.asList(Rotate.RIGHT, Rotate.RIGHT, Rotate.FORWARD), Direction.UP);
+            }
+        } else if (row2 > row1 && col1 == col2) {
+            if (currentDirection.equals(Direction.UP)) {
+                return new Cost(3, Arrays.asList(Rotate.RIGHT, Rotate.RIGHT, Rotate.FORWARD), Direction.DOWN);
+            } else if (currentDirection.equals(Direction.RIGHT)) {
+                return new Cost(2, Arrays.asList(Rotate.RIGHT, Rotate.FORWARD), Direction.DOWN);
+            } else if (currentDirection.equals(Direction.LEFT)) {
+                return new Cost(2, Arrays.asList(Rotate.LEFT, Rotate.FORWARD), Direction.DOWN);
+            } else if (currentDirection.equals(Direction.DOWN)) {
+                return new Cost(1, Arrays.asList(Rotate.FORWARD), Direction.DOWN);
+            }
+        }
+
+        if (col2 < col1 && row1 == row2) {
+            if (currentDirection.equals(Direction.UP)) {
+                return new Cost(2, Arrays.asList(Rotate.LEFT, Rotate.FORWARD), Direction.LEFT);
+            } else if (currentDirection.equals(Direction.RIGHT)) {
+                return new Cost(3, Arrays.asList(Rotate.LEFT, Rotate.LEFT, Rotate.FORWARD), Direction.LEFT);
+            } else if (currentDirection.equals(Direction.LEFT)) {
+                return new Cost(1, Arrays.asList(Rotate.FORWARD), Direction.LEFT);
+            } else if (currentDirection.equals(Direction.DOWN)) {
+                return new Cost(2, Arrays.asList(Rotate.RIGHT, Rotate.FORWARD), Direction.LEFT);
+            }
+        } else if (col2 > col1 && row1 == row2) {
+            if (currentDirection.equals(Direction.UP)) {
+                return new Cost(2, Arrays.asList(Rotate.RIGHT, Rotate.FORWARD), Direction.RIGHT);
+            } else if (currentDirection.equals(Direction.RIGHT)) {
+                return new Cost(1, Arrays.asList(Rotate.FORWARD), Direction.RIGHT);
+            } else if (currentDirection.equals(Direction.LEFT)) {
+                return new Cost(3, Arrays.asList(Rotate.RIGHT, Rotate.RIGHT, Rotate.FORWARD), Direction.RIGHT);
+            } else if (currentDirection.equals(Direction.DOWN)) {
+                return new Cost(2, Arrays.asList(Rotate.LEFT, Rotate.FORWARD), Direction.RIGHT);
+            }
+        }
+
+        return new Cost(0, null, currentDirection);
+    }
+}

--- a/src/main/java/com/mahefa/pathfindingfx/algorithm/maze/AldousBroder.java
+++ b/src/main/java/com/mahefa/pathfindingfx/algorithm/maze/AldousBroder.java
@@ -11,6 +11,7 @@ import java.util.function.Supplier;
 import static com.mahefa.pathfindingfx.ui.style.CellStyle.Flag;
 import static com.mahefa.pathfindingfx.ui.style.CellStyle.Flag.*;
 
+@Deprecated(forRemoval = true) // superseded by the Stepper/StepPlayer pipeline; kept until removal
 public class AldousBroder extends MazeGenerator {
 
     public AldousBroder(Grid grid) {

--- a/src/main/java/com/mahefa/pathfindingfx/algorithm/maze/AldousBroderStepper.java
+++ b/src/main/java/com/mahefa/pathfindingfx/algorithm/maze/AldousBroderStepper.java
@@ -1,0 +1,111 @@
+package com.mahefa.pathfindingfx.algorithm.maze;
+
+import com.mahefa.pathfindingfx.algorithm.grid.GridModel;
+import com.mahefa.pathfindingfx.algorithm.step.AbstractStepper;
+import com.mahefa.pathfindingfx.algorithm.step.StepType;
+import com.mahefa.pathfindingfx.domain.Location;
+import com.mahefa.pathfindingfx.domain.enumerator.Direction;
+
+import java.util.Random;
+
+/**
+ * Aldous-Broder as a pure {@link com.mahefa.pathfindingfx.algorithm.step.Stepper}: a random walk
+ * over the odd-coordinate cells (moving two at a time), carving the wall between when it reaches an
+ * unvisited cell, until every cell is visited. Emits steps instead of mutating cells.
+ * <p>
+ * Fixes the reported bug: the start and target cells are opened ({@code OPEN} → Flag NONE) up front
+ * instead of being left as walls. Their {@code NodeType} (START/TARGET) is a separate {@code Cell}
+ * property the renderer never touches, so it is preserved.
+ */
+public class AldousBroderStepper extends AbstractStepper {
+
+    private final boolean[][] visited;
+    private final Random random = new Random();
+
+    private Location current;
+    private int totalUnvisited;
+    private boolean initialized;
+    private boolean finished;
+
+    public AldousBroderStepper(GridModel model) {
+        super(model);
+        this.visited = new boolean[model.getRowLen()][model.getColLen()];
+        this.totalUnvisited = (model.getRowLen() / 2) * (model.getColLen() / 2);
+    }
+
+    @Override
+    protected boolean isComplete() {
+        return finished;
+    }
+
+    @Override
+    protected void advance() {
+        if (!initialized) {
+            initialized = true;
+            // BUG FIX: open start & target so they are not left as walls (NodeType is untouched).
+            markVisited(model.getStart());
+            emit(model.getStart(), StepType.OPEN);
+            markVisited(model.getTarget());
+            emit(model.getTarget(), StepType.OPEN);
+
+            current = pickRandomCell();
+            markVisited(current);
+            emit(current, StepType.CURRENT);
+            return;
+        }
+
+        if (totalUnvisited <= 0) {
+            emit(current, StepType.OPEN); // settle the final highlighted cell
+            finished = true;
+            return;
+        }
+
+        emit(current, StepType.OPEN); // leaving the current cell carves it open
+        Location neighbour = randomNeighbour(current);
+        emit(neighbour, StepType.CURRENT);
+
+        if (!isVisited(neighbour)) {
+            Location wall = new Location(
+                    (current.getRow() + neighbour.getRow()) / 2,
+                    (current.getCol() + neighbour.getCol()) / 2
+            );
+            emit(wall, StepType.OPEN);
+            markVisited(neighbour);
+        }
+
+        current = neighbour;
+    }
+
+    private Location pickRandomCell() {
+        int row = 1 + random.nextInt((model.getRowLen() - 1) / 2) * 2;
+        int col = 1 + random.nextInt((model.getColLen() - 1) / 2) * 2;
+        return new Location(row, col);
+    }
+
+    // Move two cells in a random cardinal direction (thick walls), retrying until in-bounds.
+    private Location randomNeighbour(Location from) {
+        Direction[] dirs = {Direction.UP, Direction.DOWN, Direction.LEFT, Direction.RIGHT};
+        while (true) {
+            Direction d = dirs[random.nextInt(dirs.length)];
+            Location n = from.move(d).move(d);
+            if (model.inBounds(n)) {
+                return n;
+            }
+        }
+    }
+
+    private boolean isVisited(Location l) {
+        return visited[l.getRow()][l.getCol()];
+    }
+
+    // Marks a cell visited; decrements the remaining count once per odd-coordinate ("real") cell so
+    // the walk is guaranteed to terminate when all cells have been reached.
+    private void markVisited(Location l) {
+        if (!visited[l.getRow()][l.getCol()]) {
+            visited[l.getRow()][l.getCol()] = true;
+            if (l.getRow() % 2 == 1 && l.getCol() % 2 == 1) {
+                totalUnvisited--;
+            }
+        }
+    }
+}

--- a/src/main/java/com/mahefa/pathfindingfx/algorithm/maze/MazeGenerator.java
+++ b/src/main/java/com/mahefa/pathfindingfx/algorithm/maze/MazeGenerator.java
@@ -8,6 +8,7 @@ import com.mahefa.pathfindingfx.algorithm.State;
 
 import java.util.function.Supplier;
 
+@Deprecated(forRemoval = true) // superseded by the Stepper/StepPlayer pipeline; kept until removal
 public abstract class MazeGenerator extends State {
 
     protected Grid grid;

--- a/src/main/java/com/mahefa/pathfindingfx/algorithm/maze/Randomized.java
+++ b/src/main/java/com/mahefa/pathfindingfx/algorithm/maze/Randomized.java
@@ -7,6 +7,7 @@ import com.mahefa.pathfindingfx.ui.component.Grid;
 
 import java.util.function.Supplier;
 
+@Deprecated(forRemoval = true) // superseded by the Stepper/StepPlayer pipeline; kept until removal
 public class Randomized extends MazeGenerator {
 
     public Randomized(Grid grid) {

--- a/src/main/java/com/mahefa/pathfindingfx/algorithm/maze/RandomizedPrim.java
+++ b/src/main/java/com/mahefa/pathfindingfx/algorithm/maze/RandomizedPrim.java
@@ -3,6 +3,7 @@ package com.mahefa.pathfindingfx.algorithm.maze;
 import org.springframework.stereotype.Component;
 
 @Component
+@Deprecated(forRemoval = true) // superseded by the Stepper/StepPlayer pipeline; kept until removal
 public class RandomizedPrim /*extends MazeGenerator*/ {
 
 //    @Override

--- a/src/main/java/com/mahefa/pathfindingfx/algorithm/maze/RandomizedStepper.java
+++ b/src/main/java/com/mahefa/pathfindingfx/algorithm/maze/RandomizedStepper.java
@@ -1,0 +1,44 @@
+package com.mahefa.pathfindingfx.algorithm.maze;
+
+import com.mahefa.pathfindingfx.algorithm.grid.GridModel;
+import com.mahefa.pathfindingfx.algorithm.step.AbstractStepper;
+import com.mahefa.pathfindingfx.algorithm.step.StepType;
+import com.mahefa.pathfindingfx.domain.Location;
+
+/**
+ * The basic random maze as a pure {@link com.mahefa.pathfindingfx.algorithm.step.Stepper}: scans the
+ * grid and, with ~25% probability, marks a (non-start/target) cell as a wall. Unlike the original
+ * synchronous version it now streams one wall per pulled step, so it animates like the others.
+ */
+public class RandomizedStepper extends AbstractStepper {
+
+    private int index;
+    private boolean finished;
+
+    public RandomizedStepper(GridModel model) {
+        super(model);
+    }
+
+    @Override
+    protected boolean isComplete() {
+        return finished;
+    }
+
+    @Override
+    protected void advance() {
+        int total = model.getRowLen() * model.getColLen();
+        while (index < total) {
+            int row = index / model.getColLen();
+            int col = index % model.getColLen();
+            index++;
+
+            Location location = new Location(row, col);
+            boolean special = location.equals(model.getStart()) || location.equals(model.getTarget());
+            if (!special && Math.random() < 0.25) {
+                emit(location, StepType.WALL);
+                return;
+            }
+        }
+        finished = true;
+    }
+}

--- a/src/main/java/com/mahefa/pathfindingfx/algorithm/pathfinding/AStar.java
+++ b/src/main/java/com/mahefa/pathfindingfx/algorithm/pathfinding/AStar.java
@@ -20,6 +20,7 @@ import java.util.function.Supplier;
 
 import static com.mahefa.pathfindingfx.ui.style.CellStyle.Flag;
 
+@Deprecated(forRemoval = true) // superseded by the Stepper/StepPlayer pipeline; kept until removal
 public class AStar extends Solver {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AStar.class);

--- a/src/main/java/com/mahefa/pathfindingfx/algorithm/pathfinding/AStarStepper.java
+++ b/src/main/java/com/mahefa/pathfindingfx/algorithm/pathfinding/AStarStepper.java
@@ -1,0 +1,128 @@
+package com.mahefa.pathfindingfx.algorithm.pathfinding;
+
+import com.mahefa.pathfindingfx.algorithm.collection.Heap;
+import com.mahefa.pathfindingfx.algorithm.collection.MinHeap;
+import com.mahefa.pathfindingfx.algorithm.grid.GridModel;
+import com.mahefa.pathfindingfx.algorithm.grid.Moves;
+import com.mahefa.pathfindingfx.algorithm.step.AbstractStepper;
+import com.mahefa.pathfindingfx.algorithm.step.Step;
+import com.mahefa.pathfindingfx.algorithm.step.StepType;
+import com.mahefa.pathfindingfx.domain.Cost;
+import com.mahefa.pathfindingfx.domain.Location;
+import com.mahefa.pathfindingfx.domain.RouteNode;
+import com.mahefa.pathfindingfx.domain.enumerator.Direction;
+import com.mahefa.pathfindingfx.util.ImageUtils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A* as a pure {@link com.mahefa.pathfindingfx.algorithm.step.Stepper}: one node expansion per
+ * {@link #advance()}, emitting {@code CURRENT}/{@code VISITED} steps, then the {@code PATH} steps
+ * (each carrying its cumulative arrow angle) once the target is reached. Same logic and heuristic
+ * (Manhattan) as the original {@code AStar}, reusing {@link RouteNode}/{@link MinHeap}/{@link Cost},
+ * but reading a {@link GridModel} and emitting steps instead of mutating cells.
+ */
+public class AStarStepper extends AbstractStepper {
+
+    private final Heap<RouteNode> openSet = new MinHeap<>();
+    private final Set<Location> closed = new HashSet<>();
+    private final Map<Location, RouteNode> nodes = new HashMap<>();
+    private final Location target;
+
+    private Location previousCurrent;
+    private boolean finished;
+
+    public AStarStepper(GridModel model) {
+        super(model);
+        this.target = model.getTarget();
+
+        RouteNode start = new RouteNode(model.getStart(), 0d, distance(model.getStart(), target));
+        start.setDirection(Direction.UP);
+        openSet.add(start);
+        nodes.put(model.getStart(), start);
+    }
+
+    @Override
+    protected boolean isComplete() {
+        return finished;
+    }
+
+    @Override
+    protected void advance() {
+        if (openSet.isEmpty()) {
+            finished = true; // no path
+            return;
+        }
+
+        // Settle the previously highlighted cell, then highlight the new lowest-f cell.
+        RouteNode currentNode = openSet.get();
+        Location current = currentNode.getCurrent();
+        if (previousCurrent != null && !previousCurrent.equals(current)) {
+            emit(previousCurrent, StepType.VISITED);
+        }
+        emit(current, StepType.CURRENT);
+        previousCurrent = current;
+
+        if (current.equals(target)) {
+            emitPath(currentNode);
+            finished = true;
+            return;
+        }
+
+        openSet.remove(currentNode);
+        closed.add(current);
+
+        for (Location neighbour : Moves.neighbours(model, current)) {
+            if (model.isWall(neighbour) || closed.contains(neighbour)) {
+                continue;
+            }
+
+            RouteNode neighbourNode = nodes.getOrDefault(neighbour, new RouteNode(neighbour));
+            nodes.put(neighbour, neighbourNode);
+
+            Cost cost = Moves.cost(current, neighbour, currentNode.getDirection());
+            double tentativeG = currentNode.getG() + model.weightAt(neighbour) + cost.getValue();
+
+            if (tentativeG < neighbourNode.getG()) {
+                neighbourNode.setG(tentativeG);
+                neighbourNode.setH(distance(neighbour, target));
+                neighbourNode.setF(tentativeG + neighbourNode.getH());
+                neighbourNode.setPrevious(current);
+                neighbourNode.setMoves(cost.getMoves());
+                neighbourNode.setDirection(cost.getCurrentDirection());
+
+                if (!openSet.contains(neighbourNode)) {
+                    openSet.add(neighbourNode);
+                }
+            }
+        }
+    }
+
+    /** Rebuild start→target and emit a PATH step per cell with its cumulative rotation angle. */
+    private void emitPath(RouteNode targetNode) {
+        List<RouteNode> path = new ArrayList<>();
+        RouteNode node = targetNode;
+        while (node != null) {
+            path.add(node);
+            node = (node.getPrevious() != null) ? nodes.get(node.getPrevious()) : null;
+        }
+        Collections.reverse(path);
+
+        double angle = 0d;
+        for (RouteNode step : path) {
+            angle += ImageUtils.getRotationAngle(step.getMoves());
+            emit(Step.path(step.getCurrent(), angle));
+        }
+    }
+
+    // Manhattan distance heuristic (matches the original AStar).
+    private double distance(Location a, Location b) {
+        return Math.abs(a.getRow() - b.getRow()) + Math.abs(a.getCol() - b.getCol());
+    }
+}

--- a/src/main/java/com/mahefa/pathfindingfx/algorithm/pathfinding/Solver.java
+++ b/src/main/java/com/mahefa/pathfindingfx/algorithm/pathfinding/Solver.java
@@ -9,6 +9,7 @@ import com.mahefa.pathfindingfx.algorithm.State;
 import java.util.Map;
 import java.util.function.Supplier;
 
+@Deprecated(forRemoval = true) // superseded by the Stepper/StepPlayer pipeline; kept until removal
 public abstract class Solver extends State {
 
     protected Grid grid;

--- a/src/main/java/com/mahefa/pathfindingfx/algorithm/step/AbstractStepper.java
+++ b/src/main/java/com/mahefa/pathfindingfx/algorithm/step/AbstractStepper.java
@@ -1,0 +1,59 @@
+package com.mahefa.pathfindingfx.algorithm.step;
+
+import com.mahefa.pathfindingfx.algorithm.grid.GridModel;
+import com.mahefa.pathfindingfx.domain.Location;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.NoSuchElementException;
+
+/**
+ * Shared superclass for all {@link Stepper}s (maze and pathfinding alike). Holds the state common to
+ * every algorithm — the pure {@link GridModel} it runs against and the lazy step buffer — and
+ * implements the {@link java.util.Iterator} contract on top of two small hooks:
+ * <ul>
+ *   <li>{@link #advance()} — produce the next one-or-more steps into the buffer;</li>
+ *   <li>{@link #isComplete()} — whether the algorithm has finished.</li>
+ * </ul>
+ * Subclasses just express their algorithm in terms of {@code emit(...)} + {@code isComplete()};
+ * the buffering, {@code hasNext}/{@code next} and laziness live here once.
+ */
+public abstract class AbstractStepper implements Stepper {
+
+    protected final GridModel model;
+    private final Deque<Step> buffer = new ArrayDeque<>();
+
+    protected AbstractStepper(GridModel model) {
+        this.model = model;
+    }
+
+    @Override
+    public final boolean hasNext() {
+        if (buffer.isEmpty() && !isComplete()) {
+            advance();
+        }
+        return !buffer.isEmpty();
+    }
+
+    @Override
+    public final Step next() {
+        if (!hasNext()) {
+            throw new NoSuchElementException();
+        }
+        return buffer.poll();
+    }
+
+    protected final void emit(Step step) {
+        buffer.add(step);
+    }
+
+    protected final void emit(Location location, StepType type) {
+        buffer.add(Step.of(location, type));
+    }
+
+    /** Produce the next batch of steps (at least one, unless complete). */
+    protected abstract void advance();
+
+    /** True once no more steps will ever be produced. */
+    protected abstract boolean isComplete();
+}

--- a/src/main/java/com/mahefa/pathfindingfx/algorithm/step/Step.java
+++ b/src/main/java/com/mahefa/pathfindingfx/algorithm/step/Step.java
@@ -1,0 +1,19 @@
+package com.mahefa.pathfindingfx.algorithm.step;
+
+import com.mahefa.pathfindingfx.domain.Location;
+
+/**
+ * One unit of visualization: "at this {@link Location}, this {@link StepType} happened". Pure domain
+ * data — no JavaFX. {@code angle} is only meaningful for {@link StepType#PATH} (the cumulative arrow
+ * rotation, in degrees, at that path cell); it is 0 for every other type.
+ */
+public record Step(Location location, StepType type, double angle) {
+
+    public static Step of(Location location, StepType type) {
+        return new Step(location, type, 0d);
+    }
+
+    public static Step path(Location location, double angle) {
+        return new Step(location, StepType.PATH, angle);
+    }
+}

--- a/src/main/java/com/mahefa/pathfindingfx/algorithm/step/StepType.java
+++ b/src/main/java/com/mahefa/pathfindingfx/algorithm/step/StepType.java
@@ -1,0 +1,18 @@
+package com.mahefa.pathfindingfx.algorithm.step;
+
+/**
+ * The kinds of visualization events an algorithm ({@link Stepper}) can emit. Shared by both maze
+ * generators and pathfinders so a single renderer/player handles every algorithm.
+ */
+public enum StepType {
+    /** The cell the algorithm is currently working on (transient highlight). */
+    CURRENT,
+    /** A cell finalized by a search (added to the closed set). */
+    VISITED,
+    /** A cell/passage opened (maze carve, or opening the start/target). */
+    OPEN,
+    /** A wall placed (e.g. the random maze). */
+    WALL,
+    /** A cell on the resulting shortest path (carries a rotation angle for the arrow). */
+    PATH
+}

--- a/src/main/java/com/mahefa/pathfindingfx/algorithm/step/Stepper.java
+++ b/src/main/java/com/mahefa/pathfindingfx/algorithm/step/Stepper.java
@@ -1,0 +1,12 @@
+package com.mahefa.pathfindingfx.algorithm.step;
+
+import java.util.Iterator;
+
+/**
+ * A lazy, pull-based source of {@link Step}s produced by an algorithm. Reusable across both
+ * categories of algorithm (maze generation and pathfinding) — the {@code StepPlayer} pulls from it
+ * at a speed-controlled cadence and renders each step, so the algorithm never touches the UI and
+ * a slow/open-ended one still shows output immediately (nothing is precomputed).
+ */
+public interface Stepper extends Iterator<Step> {
+}

--- a/src/main/java/com/mahefa/pathfindingfx/service/GridService.java
+++ b/src/main/java/com/mahefa/pathfindingfx/service/GridService.java
@@ -1,51 +1,143 @@
 package com.mahefa.pathfindingfx.service;
 
-import javafx.beans.binding.Bindings;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
+import com.mahefa.pathfindingfx.algorithm.maze.AldousBroderStepper;
+import com.mahefa.pathfindingfx.algorithm.maze.RandomizedStepper;
+import com.mahefa.pathfindingfx.algorithm.pathfinding.AStarStepper;
+import com.mahefa.pathfindingfx.algorithm.step.Stepper;
+import com.mahefa.pathfindingfx.algorithm.step.StepType;
+import com.mahefa.pathfindingfx.domain.Location;
+import com.mahefa.pathfindingfx.exception.MissingAlgorithmException;
+import com.mahefa.pathfindingfx.exception.UnsupportedAlgorithmException;
 import com.mahefa.pathfindingfx.domain.enumerator.AnimationSpeed;
 import com.mahefa.pathfindingfx.domain.enumerator.LaunchAnimationSpeed;
+import com.mahefa.pathfindingfx.domain.enumerator.MazeAlgorithm;
 import com.mahefa.pathfindingfx.domain.enumerator.MazeGenerationAnimationSpeed;
+import com.mahefa.pathfindingfx.domain.enumerator.PathFindingAlgorithm;
 import com.mahefa.pathfindingfx.ui.component.Grid;
-import com.mahefa.pathfindingfx.service.concurrent.MazeGeneratorWorker;
-import com.mahefa.pathfindingfx.service.concurrent.PathfindingWorker;
+import com.mahefa.pathfindingfx.service.concurrent.GridSnapshot;
+import com.mahefa.pathfindingfx.service.concurrent.RunNarrative;
+import com.mahefa.pathfindingfx.service.concurrent.StepWorker;
 import com.mahefa.pathfindingfx.service.concurrent.progress.LogCleaner;
+import com.mahefa.pathfindingfx.service.concurrent.progress.Narrative;
 
 import static com.mahefa.pathfindingfx.ui.style.CellStyle.Flag.NONE;
+import static com.mahefa.pathfindingfx.ui.style.CellStyle.Flag.WALL_NODE;
 
+/**
+ * Orchestrates algorithm runs. Both maze generation and pathfinding now flow through a single
+ * reusable {@link StepWorker}: the grid is snapshotted into a pure model, the matching
+ * {@link Stepper} is built, and the worker replays its steps at the current speed.
+ */
 public class GridService {
 
     protected Grid grid;
-    private MazeGeneratorWorker mazeGeneratorWorker;
-    private PathfindingWorker pathfindingWorker;
+    private final StepWorker stepWorker;
     private final LogCleaner logCleaner;
+
+    private PathFindingAlgorithm pathAlgorithm;
+    private AnimationSpeed currentSpeed;
+    private boolean lastRunWasMaze;
 
     private BooleanProperty isReady = new SimpleBooleanProperty(false);
 
     public GridService(Grid grid, LogCleaner logCleaner) {
         this.grid = grid;
         this.logCleaner = logCleaner;
-        this.mazeGeneratorWorker = new MazeGeneratorWorker(grid);
-        this.pathfindingWorker = new PathfindingWorker(grid);
+        this.stepWorker = new StepWorker(grid);
 
-        isReady.bind(
-                Bindings.and(
-                        mazeGeneratorWorker.runningProperty().not(),
-                        pathfindingWorker.runningProperty().not()
-                )
-        );
+        isReady.bind(stepWorker.runningProperty().not());
     }
 
     public Grid getGrid() {
         return grid;
     }
 
-    public MazeGeneratorWorker getMazeGeneratorWorker() {
-        return mazeGeneratorWorker;
+    /** Selects the pathfinding algorithm to use on the next {@link #findPath()}. */
+    public void setPathAlgorithm(PathFindingAlgorithm algorithm) {
+        this.pathAlgorithm = algorithm;
     }
 
-    public PathfindingWorker getPathfindingWorker() {
-        return pathfindingWorker;
+    public void generateMaze(MazeAlgorithm algorithm) {
+        lastRunWasMaze = true;
+        Stepper stepper;
+        switch (algorithm) {
+            case ALDOUS_BRODER -> {
+                grid.setDefaultFlag(WALL_NODE);
+                grid.clear(true, false, false);
+                stepper = new AldousBroderStepper(GridSnapshot.of(grid));
+            }
+            case BASIC_RANDOM -> {
+                grid.setDefaultFlag(NONE);
+                grid.clear(true, false, false);
+                stepper = new RandomizedStepper(GridSnapshot.of(grid));
+            }
+            default -> throw new UnsupportedAlgorithmException("Unsupported algorithm: " + algorithm);
+        }
+        run(stepper, mazeNarrative(algorithm));
+    }
+
+    public void findPath() {
+        if (pathAlgorithm == null) {
+            throw new MissingAlgorithmException("Pick an Algorithm!");
+        }
+
+        lastRunWasMaze = false;
+        switch (pathAlgorithm) {
+            case A_STAR -> {
+                grid.clear(false, false, false);
+                // The shortest-path arrow animates at a fixed speed, like the original (independent
+                // of the search-speed slider), so it stays quick even when the search is set to slow.
+                run(new AStarStepper(GridSnapshot.of(grid)), pathfindingNarrative(),
+                        LaunchAnimationSpeed.SHORTEST_PATH.getInterval());
+            }
+            default -> throw new UnsupportedAlgorithmException("Unsupported algorithm: " + pathAlgorithm);
+        }
+    }
+
+    private void run(Stepper stepper, RunNarrative narrative) {
+        run(stepper, narrative, 0L);
+    }
+
+    private void run(Stepper stepper, RunNarrative narrative, long pathIntervalNanos) {
+        if (currentSpeed != null) {
+            stepWorker.setCurrentSpeed(intervalFor(currentSpeed));
+        }
+        stepWorker.run(stepper, narrative, pathIntervalNanos);
+    }
+
+    private RunNarrative mazeNarrative(MazeAlgorithm algorithm) {
+        String header = String.format("%s maze %s %s  %s  %d×%d grid",
+                Narrative.START, Narrative.DOT, algorithm.getLabel(), Narrative.ARROW,
+                grid.getRowLen(), grid.getColLen());
+        int cells = grid.getRowLen() * grid.getColLen();
+        return new RunNarrative(header, null, "carving",
+                tally -> tally.total() + " steps",
+                (tally, secs) -> String.format("%s Maze ready %s %d cells %s %s",
+                        Narrative.OK, Narrative.DOT, cells, Narrative.DOT, Narrative.human(secs)),
+                tally -> true);
+    }
+
+    private RunNarrative pathfindingNarrative() {
+        Location start = grid.getStartCell().getLocation();
+        Location target = grid.getTargetCell().getLocation();
+        String header = String.format("%s pathfinding %s %s  %s  %d×%d grid",
+                Narrative.START, Narrative.DOT, pathAlgorithm.getLabel(), Narrative.ARROW,
+                grid.getRowLen(), grid.getColLen());
+        String config = String.format("  start (%d,%d) %s target (%d,%d) %s Manhattan",
+                start.getRow(), start.getCol(), Narrative.DOT, target.getRow(), target.getCol(), Narrative.DOT);
+
+        return new RunNarrative(header, config, "search",
+                tally -> tally.count(StepType.VISITED) + " cells explored",
+                (tally, secs) -> tally.count(StepType.PATH) > 0
+                        ? String.format("%s Path found %s %d steps %s %d cells explored %s %s",
+                                Narrative.OK, Narrative.DOT, tally.count(StepType.PATH), Narrative.DOT,
+                                tally.count(StepType.VISITED), Narrative.DOT, Narrative.human(secs))
+                        : String.format("%s No path %s %d cells explored %s %s",
+                                Narrative.FAIL, Narrative.DOT, tally.count(StepType.VISITED), Narrative.DOT,
+                                Narrative.human(secs)),
+                tally -> tally.count(StepType.PATH) > 0);
     }
 
     public boolean isReady() {
@@ -60,23 +152,22 @@ public class GridService {
         this.isReady.set(isReady);
     }
 
-    /**
-     * Cancels both workers if they're running. Used to recover from an exception raised
-     * before either worker's AnimationTimer ever started (e.g. no algorithm selected yet).
-     */
     public void cancelRunningWorkers() {
-        if (mazeGeneratorWorker.isRunning()) {
-            mazeGeneratorWorker.cancel();
-        }
-
-        if (pathfindingWorker.isRunning()) {
-            pathfindingWorker.cancel();
+        if (stepWorker.isRunning()) {
+            stepWorker.cancel();
         }
     }
 
     public void updateSpeed(AnimationSpeed currentSpeed) {
-        getMazeGeneratorWorker().setCurrentSpeed(MazeGenerationAnimationSpeed.valueOf(currentSpeed.name()).getInterval());
-        getPathfindingWorker().setCurrentSpeed(LaunchAnimationSpeed.valueOf(currentSpeed.name()).getInterval());
+        this.currentSpeed = currentSpeed;
+        stepWorker.setCurrentSpeed(intervalFor(currentSpeed));
+    }
+
+    // Maze and pathfinding use different speed scales; pick the right one for what's (about to be) running.
+    private long intervalFor(AnimationSpeed speed) {
+        return lastRunWasMaze
+                ? MazeGenerationAnimationSpeed.valueOf(speed.name()).getInterval()
+                : LaunchAnimationSpeed.valueOf(speed.name()).getInterval();
     }
 
     public void clearBoard() {

--- a/src/main/java/com/mahefa/pathfindingfx/service/concurrent/GridSnapshot.java
+++ b/src/main/java/com/mahefa/pathfindingfx/service/concurrent/GridSnapshot.java
@@ -1,0 +1,35 @@
+package com.mahefa.pathfindingfx.service.concurrent;
+
+import com.mahefa.pathfindingfx.algorithm.grid.GridModel;
+import com.mahefa.pathfindingfx.ui.component.Cell;
+import com.mahefa.pathfindingfx.ui.component.Grid;
+
+import static com.mahefa.pathfindingfx.ui.style.CellStyle.Flag.WALL_NODE;
+
+/**
+ * Reads the live {@link Grid} once into a pure {@link GridModel} for an algorithm run. This is the
+ * UI→algorithm boundary: after this snapshot, the stepper never touches the grid.
+ */
+public final class GridSnapshot {
+
+    private GridSnapshot() {
+    }
+
+    public static GridModel of(Grid grid) {
+        int rows = grid.getRowLen();
+        int cols = grid.getColLen();
+        boolean[][] wall = new boolean[rows][cols];
+        double[][] weight = new double[rows][cols];
+
+        for (int r = 0; r < rows; r++) {
+            for (int c = 0; c < cols; c++) {
+                Cell cell = grid.getCellAt(r, c);
+                wall[r][c] = cell.getFlag() == WALL_NODE;
+                weight[r][c] = cell.getWeight();
+            }
+        }
+
+        return new GridModel(rows, cols, wall, weight,
+                grid.getStartCell().getLocation(), grid.getTargetCell().getLocation());
+    }
+}

--- a/src/main/java/com/mahefa/pathfindingfx/service/concurrent/MazeGeneratorWorker.java
+++ b/src/main/java/com/mahefa/pathfindingfx/service/concurrent/MazeGeneratorWorker.java
@@ -19,6 +19,7 @@ import static com.mahefa.pathfindingfx.ui.style.CellStyle.Flag.WALL_NODE;
  * {@link javafx.concurrent.Worker}-based equivalent of the former {@code MazeService},
  * reusing the existing {@link MazeGenerator} implementations unchanged.
  */
+@Deprecated(forRemoval = true) // superseded by the Stepper/StepPlayer pipeline; kept until removal
 public class MazeGeneratorWorker extends AnimationWorker<MazeGenerator> {
 
     private final Grid grid;

--- a/src/main/java/com/mahefa/pathfindingfx/service/concurrent/PathfindingWorker.java
+++ b/src/main/java/com/mahefa/pathfindingfx/service/concurrent/PathfindingWorker.java
@@ -14,6 +14,7 @@ import com.mahefa.pathfindingfx.algorithm.pathfinding.Solver;
  * {@link javafx.concurrent.Worker}-based equivalent of the former {@code RouteFinderService},
  * reusing the existing {@link Solver}/{@link AStar} implementations unchanged.
  */
+@Deprecated(forRemoval = true) // superseded by the Stepper/StepPlayer pipeline; kept until removal
 public class PathfindingWorker extends AnimationWorker<Solver> {
 
     private final Grid grid;

--- a/src/main/java/com/mahefa/pathfindingfx/service/concurrent/RunNarrative.java
+++ b/src/main/java/com/mahefa/pathfindingfx/service/concurrent/RunNarrative.java
@@ -1,0 +1,25 @@
+package com.mahefa.pathfindingfx.service.concurrent;
+
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+/**
+ * The narrative for one algorithm run, supplied by the caller (which knows the algorithm, grid and
+ * start/target) so the generic {@link StepWorker} can log a story without knowing the algorithm:
+ * <ul>
+ *   <li>{@code header}/{@code configLine} — the {@code ▶ …} lines logged when the run starts;</li>
+ *   <li>{@code activityLabel} — the live spinner label (e.g. "search" / "carving");</li>
+ *   <li>{@code liveMetrics} — the animated line's metric text, derived from the live {@link StepTally};</li>
+ *   <li>{@code summary} — the closing {@code ✓/✗ …} line, from the tally + elapsed seconds;</li>
+ *   <li>{@code success} — whether the run succeeded (drives the ✓ vs ✗ marker).</li>
+ * </ul>
+ */
+public record RunNarrative(
+        String header,
+        String configLine,
+        String activityLabel,
+        Function<StepTally, String> liveMetrics,
+        BiFunction<StepTally, Long, String> summary,
+        Predicate<StepTally> success) {
+}

--- a/src/main/java/com/mahefa/pathfindingfx/service/concurrent/StepPlayer.java
+++ b/src/main/java/com/mahefa/pathfindingfx/service/concurrent/StepPlayer.java
@@ -1,0 +1,111 @@
+package com.mahefa.pathfindingfx.service.concurrent;
+
+import com.mahefa.pathfindingfx.algorithm.step.Step;
+import com.mahefa.pathfindingfx.algorithm.step.StepType;
+import com.mahefa.pathfindingfx.algorithm.step.Stepper;
+import javafx.animation.AnimationTimer;
+
+import java.util.function.Consumer;
+
+/**
+ * Replays a {@link Stepper}'s steps onto a renderer at a speed-controlled cadence. This is the ONLY
+ * place that decides timing; algorithms stay pure. Speed is {@code intervalNanos} = the minimum time
+ * between steps (smaller = faster), matching the app's {@code *AnimationSpeed} enums.
+ * <p>
+ * {@link StepType#PATH} steps are paced by a separate, fixed {@code pathIntervalNanos} (0 = "use the
+ * search interval"). This mirrors the original A*, whose shortest-path "drawback" always ran at a
+ * fixed speed ({@code LaunchAnimationSpeed.SHORTEST_PATH}) regardless of the search-speed slider.
+ * <p>
+ * {@link #pulse(long)} is the pure, testable core: given the frame timestamp, it applies as many
+ * pending steps as the elapsed time allows and returns the count.
+ */
+public final class StepPlayer {
+
+    private final Stepper stepper;
+    private final Consumer<Step> renderer;
+    private volatile long intervalNanos;      // search / generation cadence (live)
+    private final long pathIntervalNanos;     // fixed cadence for PATH steps (0 = same as above)
+
+    private Step pending; // one-step lookahead so we can pace by the next step's type
+    private long lastToggle;
+    private boolean started;
+
+    public StepPlayer(Stepper stepper, Consumer<Step> renderer, long intervalNanos) {
+        this(stepper, renderer, intervalNanos, 0L);
+    }
+
+    public StepPlayer(Stepper stepper, Consumer<Step> renderer, long intervalNanos, long pathIntervalNanos) {
+        this.stepper = stepper;
+        this.renderer = renderer;
+        this.intervalNanos = Math.max(1L, intervalNanos);
+        this.pathIntervalNanos = pathIntervalNanos;
+    }
+
+    /** Live speed change for search/generation (PATH steps keep their fixed cadence). */
+    public void setIntervalNanos(long intervalNanos) {
+        this.intervalNanos = Math.max(1L, intervalNanos);
+    }
+
+    public long getIntervalNanos() {
+        return intervalNanos;
+    }
+
+    public boolean isFinished() {
+        return peek() == null;
+    }
+
+    /**
+     * Apply as many steps as {@code now} allows since the last one; returns the count applied. Each
+     * step is paced by the interval for its own {@link StepType}. The first pulse is seeded so a
+     * single step fires immediately (no blank first frame).
+     */
+    public int pulse(long now) {
+        Step next = peek();
+        if (!started) {
+            started = true;
+            lastToggle = now - ((next != null) ? intervalFor(next.type()) : intervalNanos);
+        }
+
+        int applied = 0;
+        while ((next = peek()) != null) {
+            long interval = intervalFor(next.type());
+            if ((now - lastToggle) < interval) {
+                break;
+            }
+            renderer.accept(take());
+            lastToggle += interval;
+            applied++;
+        }
+        return applied;
+    }
+
+    private long intervalFor(StepType type) {
+        return (type == StepType.PATH && pathIntervalNanos > 0) ? pathIntervalNanos : intervalNanos;
+    }
+
+    private Step peek() {
+        if (pending == null && stepper.hasNext()) {
+            pending = stepper.next();
+        }
+        return pending;
+    }
+
+    private Step take() {
+        Step step = peek();
+        pending = null;
+        return step;
+    }
+
+    /** Wraps this player in an {@link AnimationTimer} for use on the FX thread. */
+    public AnimationTimer asAnimationTimer() {
+        return new AnimationTimer() {
+            @Override
+            public void handle(long now) {
+                pulse(now);
+                if (isFinished()) {
+                    stop();
+                }
+            }
+        };
+    }
+}

--- a/src/main/java/com/mahefa/pathfindingfx/service/concurrent/StepTally.java
+++ b/src/main/java/com/mahefa/pathfindingfx/service/concurrent/StepTally.java
@@ -1,0 +1,27 @@
+package com.mahefa.pathfindingfx.service.concurrent;
+
+import com.mahefa.pathfindingfx.algorithm.step.StepType;
+
+/**
+ * Running counts of the steps rendered so far, by {@link StepType} plus a grand total. Updated on
+ * the FX thread as the {@link StepPlayer} applies each step; read by the narrative (live metric +
+ * summary) so it can describe progress without the algorithm having to report anything itself.
+ */
+public final class StepTally {
+
+    private int total;
+    private final int[] counts = new int[StepType.values().length];
+
+    public void record(StepType type) {
+        total++;
+        counts[type.ordinal()]++;
+    }
+
+    public int total() {
+        return total;
+    }
+
+    public int count(StepType type) {
+        return counts[type.ordinal()];
+    }
+}

--- a/src/main/java/com/mahefa/pathfindingfx/service/concurrent/StepWorker.java
+++ b/src/main/java/com/mahefa/pathfindingfx/service/concurrent/StepWorker.java
@@ -1,0 +1,107 @@
+package com.mahefa.pathfindingfx.service.concurrent;
+
+import com.mahefa.pathfindingfx.algorithm.step.Step;
+import com.mahefa.pathfindingfx.algorithm.step.Stepper;
+import com.mahefa.pathfindingfx.service.concurrent.progress.Narrative;
+import com.mahefa.pathfindingfx.service.concurrent.progress.ProgressReporter;
+import com.mahefa.pathfindingfx.ui.component.Grid;
+import com.mahefa.pathfindingfx.ui.component.GridStepRenderer;
+import javafx.animation.AnimationTimer;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * A single, reusable {@link AnimationWorker} that drives ANY {@link Stepper} — maze generator or
+ * pathfinder alike — through a {@link StepPlayer} rendering onto the grid via {@link GridStepRenderer}.
+ * One worker + one player + one renderer for every algorithm; a new algorithm is just a new
+ * {@code Stepper}. Speed changes are forwarded live, and each run's narrative (▶ header, live
+ * spinner, ✓/✗ summary) is produced from a caller-supplied {@link RunNarrative} + live {@link StepTally}.
+ */
+public class StepWorker extends AnimationWorker<Object> {
+
+    private static final long DEFAULT_INTERVAL_NANOS = 25_000_000L; // 25 ms
+
+    private final Grid grid;
+    private final BooleanProperty running = new SimpleBooleanProperty(false);
+    private final ProgressReporter reporter = new ProgressReporter();
+
+    private StepPlayer player;
+    private RunNarrative narrative;
+    private StepTally tally;
+
+    public StepWorker(Grid grid) {
+        this.grid = grid;
+    }
+
+    @Override
+    protected void onSpeedChanged(Long speed) {
+        if (player != null && speed != null) {
+            player.setIntervalNanos(speed);
+        }
+    }
+
+    /** Runs the given stepper, rendering each step onto the grid at the current speed. */
+    public void run(Stepper stepper, RunNarrative narrative) {
+        run(stepper, narrative, 0L);
+    }
+
+    /**
+     * Runs the stepper at the current speed, pacing {@link com.mahefa.pathfindingfx.algorithm.step.StepType#PATH}
+     * steps at the fixed {@code pathIntervalNanos} (0 = same as the search speed).
+     */
+    public void run(Stepper stepper, RunNarrative narrative, long pathIntervalNanos) {
+        if (isRunning()) {
+            cancel();
+        }
+
+        this.narrative = narrative;
+        this.tally = new StepTally();
+
+        GridStepRenderer gridRenderer = new GridStepRenderer(grid);
+        Consumer<Step> renderer = step -> {
+            gridRenderer.accept(step);
+            tally.record(step.type());
+        };
+
+        long interval = (getCurrentSpeed() != null) ? getCurrentSpeed() : DEFAULT_INTERVAL_NANOS;
+        player = new StepPlayer(stepper, renderer, interval, pathIntervalNanos);
+
+        updateMessage(narrative.header());
+        reporter.start(narrative.header(), narrative.configLine(), narrative.activityLabel(),
+                () -> narrative.liveMetrics().apply(tally));
+
+        running.set(true);
+        Supplier<AnimationTimer> supplier = () -> new AnimationTimer() {
+            @Override
+            public void handle(long now) {
+                player.pulse(now);
+                if (player.isFinished()) {
+                    running.set(false);
+                    stop();
+                }
+            }
+        };
+
+        begin(supplier, running, this);
+    }
+
+    @Override
+    protected void onSucceeded() {
+        String summary = narrative.summary().apply(tally, reporter.elapsedSeconds());
+        updateMessage(summary);
+        reporter.finish(narrative.success().test(tally), summary);
+    }
+
+    @Override
+    protected void onCancelled() {
+        if (!reporter.isReporting()) {
+            return;
+        }
+        String summary = Narrative.FAIL + " Cancelled " + Narrative.DOT + " " + Narrative.human(reporter.elapsedSeconds());
+        updateMessage(summary);
+        reporter.finish(false, summary);
+    }
+}

--- a/src/main/java/com/mahefa/pathfindingfx/ui/component/GridStepRenderer.java
+++ b/src/main/java/com/mahefa/pathfindingfx/ui/component/GridStepRenderer.java
@@ -1,0 +1,76 @@
+package com.mahefa.pathfindingfx.ui.component;
+
+import com.mahefa.pathfindingfx.algorithm.step.Step;
+import com.mahefa.pathfindingfx.domain.Location;
+import com.mahefa.pathfindingfx.domain.enumerator.NodeType;
+import javafx.scene.image.Image;
+import javafx.scene.image.ImageView;
+
+import java.util.function.Consumer;
+
+import static com.mahefa.pathfindingfx.ui.style.CellStyle.Flag;
+
+/**
+ * The production side of the record/replay split: applies {@link Step}s to the real {@link Grid} on
+ * the FX thread. The ONLY thing that touches {@code Cell}s — algorithms stay UI-free. Called from
+ * the {@code StepPlayer}'s {@code AnimationTimer}, so all mutations happen on the FX thread. A fresh
+ * instance is used per run, so the PATH arrow state below resets each time.
+ * <p>
+ * Most types are a stateless {@link com.mahefa.pathfindingfx.algorithm.step.StepType}→{@link Flag}
+ * map. {@code PATH} reproduces the original A* "drawback": a single arrow {@code ImageView} travels
+ * to the target, rotating per cell (angle carried on the {@link Step}), colouring the path behind it.
+ * NodeType (START/TARGET) is never touched, so special cells keep their identity.
+ */
+public final class GridStepRenderer implements Consumer<Step> {
+
+    private final Grid grid;
+
+    // PATH ("drawback") state: one arrow that walks the path to the target.
+    private ImageView arrow;
+    private Cell priorPathCell;
+
+    public GridStepRenderer(Grid grid) {
+        this.grid = grid;
+    }
+
+    @Override
+    public void accept(Step step) {
+        Location location = step.location();
+        Cell cell = grid.getCellAt(location.getRow(), location.getCol());
+
+        switch (step.type()) {
+            case CURRENT -> cell.setFlag(Flag.CURRENT);
+            case VISITED -> cell.setFlag(Flag.VISITED);
+            case OPEN -> cell.setFlag(Flag.NONE);
+            case WALL -> cell.setFlag(Flag.WALL_NODE);
+            case PATH -> renderPath(cell, step.angle());
+        }
+    }
+
+    // Ported from AStar.drawback(): move a single rotating arrow from cell to cell along the path.
+    private void renderPath(Cell cell, double angle) {
+        if (arrow == null) {
+            cell.getStyleClass().add("transparent");
+            arrow = new ImageView(new Image("/icons/triangletwo-up.png"));
+        }
+
+        if (priorPathCell != null && priorPathCell.getNodeType() == NodeType.NONE
+                && !priorPathCell.getChildren().isEmpty()) {
+            priorPathCell.getChildren().remove(0);
+        }
+
+        arrow.setRotate(angle);
+        cell.setFlag(Flag.SHORTEST_PATH_NODE);
+
+        if (cell.getNodeType() == NodeType.TARGET) {
+            if (!cell.getChildren().isEmpty() && cell.getChildren().get(0) instanceof ImageView imageView) {
+                imageView.setImage(arrow.getImage());
+                imageView.setRotate(angle);
+            }
+        } else if (!cell.isSpecialNode()) {
+            cell.getChildren().add(arrow);
+        }
+
+        priorPathCell = cell;
+    }
+}

--- a/src/main/java/com/mahefa/pathfindingfx/ui/controller/MainWindowController.java
+++ b/src/main/java/com/mahefa/pathfindingfx/ui/controller/MainWindowController.java
@@ -289,8 +289,7 @@ public class MainWindowController {
         if (gridService == null)
             throw new PathFindingException("Service not instantiated properly");
 
-        gridService.getMazeGeneratorWorker().setAlgorithm(MazeAlgorithm.valueOf(algorithm));
-        gridService.getMazeGeneratorWorker().start();
+        gridService.generateMaze(MazeAlgorithm.valueOf(algorithm));
 
         // Release
         currentMenu.selectedItemProperty().setValue(null);
@@ -344,7 +343,7 @@ public class MainWindowController {
         btnPlay.getLabel().setText(btnTxtArg + "!");
 
         // Update service
-        gridService.getPathfindingWorker().setAlgorithm(algorithm);
+        gridService.setPathAlgorithm(algorithm);
     }
 
     private void menuAction(Menu currentMenu) {
@@ -366,7 +365,7 @@ public class MainWindowController {
     private void execute() {
         try {
             if (gridService.isReady()) {
-                gridService.getPathfindingWorker().start();
+                gridService.findPath();
             }
         } catch (Exception e) {
             if (e instanceof MissingAlgorithmException) {

--- a/src/test/java/com/mahefa/pathfindingfx/algorithm/pathfinding/AStarStepperTest.java
+++ b/src/test/java/com/mahefa/pathfindingfx/algorithm/pathfinding/AStarStepperTest.java
@@ -1,0 +1,43 @@
+package com.mahefa.pathfindingfx.algorithm.pathfinding;
+
+import com.mahefa.pathfindingfx.algorithm.grid.GridModel;
+import com.mahefa.pathfindingfx.algorithm.step.Step;
+import com.mahefa.pathfindingfx.algorithm.step.StepType;
+import com.mahefa.pathfindingfx.domain.Location;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Confirms A* still works through the new Stepper pipeline: on an open grid it reaches the target,
+ * emits VISITED steps during the search and a PATH (with increasing arrow angle data) at the end.
+ */
+class AStarStepperTest {
+
+    private static GridModel openGrid(int rows, int cols, Location start, Location target) {
+        return new GridModel(rows, cols, new boolean[rows][cols], new double[rows][cols], start, target);
+    }
+
+    @Test
+    void findsPathAndEmitsPathSteps() {
+        AStarStepper stepper = new AStarStepper(openGrid(9, 9, new Location(1, 1), new Location(7, 7)));
+
+        List<Step> steps = new ArrayList<>();
+        int guard = 0;
+        while (stepper.hasNext() && guard++ < 1_000_000) {
+            steps.add(stepper.next());
+        }
+
+        assertFalse(stepper.hasNext(), "search should terminate");
+
+        long visited = steps.stream().filter(s -> s.type() == StepType.VISITED).count();
+        long pathCells = steps.stream().filter(s -> s.type() == StepType.PATH).count();
+
+        assertTrue(visited > 0, "A* should explore cells");
+        assertTrue(pathCells > 0, "A* should emit a shortest path (arrow steps)");
+    }
+}

--- a/src/test/java/com/mahefa/pathfindingfx/service/concurrent/StepPlayerPathSpeedTest.java
+++ b/src/test/java/com/mahefa/pathfindingfx/service/concurrent/StepPlayerPathSpeedTest.java
@@ -1,0 +1,55 @@
+package com.mahefa.pathfindingfx.service.concurrent;
+
+import com.mahefa.pathfindingfx.algorithm.step.Step;
+import com.mahefa.pathfindingfx.algorithm.step.StepType;
+import com.mahefa.pathfindingfx.algorithm.step.Stepper;
+import com.mahefa.pathfindingfx.domain.Location;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Locks in the original behaviour: the shortest-path (PATH) animation runs at its own fixed, fast
+ * interval and is NOT slowed by the search-speed slider (in the original, the drawback used
+ * {@code LaunchAnimationSpeed.SHORTEST_PATH} regardless of the chosen search speed).
+ */
+class StepPlayerPathSpeedTest {
+
+    private static Stepper of(List<Step> steps) {
+        Iterator<Step> it = steps.iterator();
+        return new Stepper() {
+            @Override public boolean hasNext() { return it.hasNext(); }
+            @Override public Step next() { return it.next(); }
+        };
+    }
+
+    @Test
+    void pathStepsUseTheFixedFastIntervalNotTheSlowSearchSpeed() {
+        long slowSearch = 1_000_000_000L; // 1 s per search step
+        long fastPath = 10_000_000L;      // 10 ms per path step (fixed)
+
+        List<Step> steps = new ArrayList<>();
+        steps.add(Step.of(new Location(0, 0), StepType.CURRENT)); // one search step
+        for (int i = 0; i < 30; i++) {
+            steps.add(Step.path(new Location(1, i), i)); // then the path
+        }
+
+        AtomicInteger rendered = new AtomicInteger();
+        StepPlayer player = new StepPlayer(of(steps), s -> rendered.incrementAndGet(), slowSearch, fastPath);
+
+        player.pulse(0L);                 // seeds + renders the first (CURRENT) step
+        int afterSearch = rendered.get();
+
+        player.pulse(100_000_000L);       // 100 ms later
+        int pathRendered = rendered.get() - afterSearch;
+
+        // At 10 ms/step, ~100 ms renders many path cells; at the 1 s search speed it would render 0.
+        assertTrue(pathRendered >= 5,
+                "PATH should pace at the fixed fast interval (rendered " + pathRendered + " in 100ms)");
+    }
+}

--- a/src/test/java/com/mahefa/pathfindingfx/service/concurrent/StepPlayerSpeedTest.java
+++ b/src/test/java/com/mahefa/pathfindingfx/service/concurrent/StepPlayerSpeedTest.java
@@ -1,0 +1,88 @@
+package com.mahefa.pathfindingfx.service.concurrent;
+
+import com.mahefa.pathfindingfx.algorithm.grid.GridModel;
+import com.mahefa.pathfindingfx.algorithm.maze.AldousBroderStepper;
+import com.mahefa.pathfindingfx.algorithm.step.Stepper;
+import com.mahefa.pathfindingfx.domain.Location;
+import com.mahefa.pathfindingfx.domain.enumerator.MazeGenerationAnimationSpeed;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Proves the key property of the record/replay design: the speed setting controls how much of the
+ * visualization renders per unit time, and a slow/open-ended algorithm (Aldous-Broder) still renders
+ * immediately (no precompute freeze). Fully headless — drives {@link StepPlayer#pulse} with synthetic
+ * frame timestamps and counts applied steps; no JavaFX toolkit involved.
+ */
+class StepPlayerSpeedTest {
+
+    private static final long FRAME_DT = 16_666_667L; // ~60 fps
+    private static final int FRAMES = 120;            // ~2 seconds of playback
+    private static final long START_NOW = 1_000_000_000L;
+
+    private static GridModel maze(int rows, int cols) {
+        boolean[][] wall = new boolean[rows][cols];
+        double[][] weight = new double[rows][cols];
+        return new GridModel(rows, cols, wall, weight, new Location(1, 1), new Location(rows - 2, cols - 2));
+    }
+
+    private int render(long intervalNanos, Stepper stepper) {
+        AtomicInteger rendered = new AtomicInteger();
+        StepPlayer player = new StepPlayer(stepper, step -> rendered.incrementAndGet(), intervalNanos);
+        long now = START_NOW;
+        for (int i = 0; i < FRAMES; i++) {
+            player.pulse(now);
+            now += FRAME_DT;
+        }
+        return rendered.get();
+    }
+
+    // Big enough that the random walk never finishes within the frame budget, so counts reflect SPEED.
+    private Stepper bigMaze() {
+        return new AldousBroderStepper(maze(51, 51));
+    }
+
+    @Test
+    void fasterSpeedRendersMoreStepsInTheSameTime() {
+        int fast = render(MazeGenerationAnimationSpeed.FAST.getInterval(), bigMaze());
+        int average = render(MazeGenerationAnimationSpeed.AVERAGE.getInterval(), bigMaze());
+        int slow = render(MazeGenerationAnimationSpeed.SLOW.getInterval(), bigMaze());
+
+        System.out.printf("rendered over ~2s — fast=%d, average=%d, slow=%d%n", fast, average, slow);
+
+        assertTrue(fast > average, "FAST should render more than AVERAGE (fast=" + fast + ", avg=" + average + ")");
+        assertTrue(average > slow, "AVERAGE should render more than SLOW (avg=" + average + ", slow=" + slow + ")");
+        assertTrue(slow <= 5, "SLOW should render only a few steps over ~2s, was " + slow);
+        assertTrue(fast >= 100, "FAST should render many steps over ~2s, was " + fast);
+    }
+
+    @Test
+    void slowAlgorithmRendersOnTheVeryFirstFrame() {
+        AtomicInteger rendered = new AtomicInteger();
+        StepPlayer player = new StepPlayer(bigMaze(), step -> rendered.incrementAndGet(),
+                MazeGenerationAnimationSpeed.SLOW.getInterval());
+
+        int appliedOnFirstPulse = player.pulse(START_NOW);
+
+        assertTrue(appliedOnFirstPulse >= 1, "expected an immediate first step, got " + appliedOnFirstPulse);
+    }
+
+    @Test
+    void aldousBroderStreamsToCompletion() {
+        Stepper stepper = new AldousBroderStepper(maze(7, 7));
+
+        int steps = 0;
+        int guard = 0;
+        while (stepper.hasNext() && guard++ < 1_000_000) {
+            stepper.next();
+            steps++;
+        }
+
+        assertFalse(stepper.hasNext(), "stepper should terminate");
+        assertTrue(steps > 0, "stepper should emit steps");
+    }
+}


### PR DESCRIPTION
Base = `11-cell-animation`.

## What
Replace the per-algorithm `AnimationTimer` approach with a reusable **record/replay** pipeline: algorithms are pure `Stepper`s that emit `Step`s; one `StepPlayer` replays them onto the grid at a speed-controlled cadence; one `StepWorker` drives any stepper. Works for both maze generation and pathfinding.

## Why
Previously each algorithm *was* an `AnimationTimer` that threw its own throttle, mutated `Cell` flags, and drew arrows — computation, timing and rendering tangled together, not reusable, not testable. This separates the three concerns.

## Changes
- `algorithm.step`: `Step` / `StepType` / `Stepper` + `AbstractStepper` (shared superclass: pure `GridModel` + lazy step buffer; subclasses implement only `advance()`/`isComplete()`).
- `algorithm.grid`: JavaFX-free `GridModel` snapshot + `Moves` (neighbours + A* turn cost, ported from `GridUtils` to operate on `Location`).
- Steppers: `AStarStepper` (search + PATH steps carrying the arrow angle), `AldousBroderStepper`, `RandomizedStepper` — pure, reuse `RouteNode`/`MinHeap`/`Cost`.
- `service.concurrent`: `StepPlayer` (speed-controlled, testable `pulse(now)`); reusable `StepWorker`; `GridSnapshot` (UI→model boundary); `StepTally` + `RunNarrative` (per-run narrative for any algorithm).
- `ui.component.GridStepRenderer`: the only UI-touching piece — `StepType`→`Cell` flag, plus a faithful port of the A* shortest-path arrow.
- `GridService.generateMaze`/`findPath` now flow through the single `StepWorker`; controller rewired.

## Fixes / fidelity
- **Aldous-Broder start/target bug**: they were left as walls; now opened (Flag NONE) up front, with `NodeType` (START/TARGET) preserved.
- Restored the moving shortest-path **arrow** and the **worker narrative** log.
- **Path animation speed**: PATH steps run at a fixed interval (`LaunchAnimationSpeed.SHORTEST_PATH`), independent of the search-speed slider — matching the previous behaviour where the path draw stayed fast even on SLOW.

## Deprecations (not modified)
`AStar`, `Solver`, `State`, `MazeGenerator`, `AldousBroder`, `Randomized`, `RandomizedPrim` and the old workers are marked `@Deprecated(forRemoval = true)`, kept until a later removal.

## Testing
- `mvn test` green — 5 tests: `StepPlayerSpeedTest` (speed controls pacing; slow algo renders immediately), `StepPlayerPathSpeedTest` (PATH paces at the fixed fast interval regardless of search speed), `AStarStepperTest` (A* reaches target and emits path steps).
- App boots clean (Spring + FXML + wiring). Manual check: run maze (Aldous-Broder start/target open, speed changes pacing) and A* (path arrow draws fast even on SLOW search).

🤖 Generated with [Claude Code](https://claude.com/claude-code)