### PR TITLE
Recompute the path instantly while dragging start/target

### DIFF
--- a/src/main/java/com/mahefa/pathfindingfx/service/GridService.java
+++ b/src/main/java/com/mahefa/pathfindingfx/service/GridService.java
@@ -16,6 +16,7 @@ import com.mahefa.pathfindingfx.domain.enumerator.MazeAlgorithm;
 import com.mahefa.pathfindingfx.domain.enumerator.MazeGenerationAnimationSpeed;
 import com.mahefa.pathfindingfx.domain.enumerator.PathFindingAlgorithm;
 import com.mahefa.pathfindingfx.ui.component.Grid;
+import com.mahefa.pathfindingfx.ui.component.GridStepRenderer;
 import com.mahefa.pathfindingfx.service.concurrent.GridSnapshot;
 import com.mahefa.pathfindingfx.service.concurrent.RunNarrative;
 import com.mahefa.pathfindingfx.service.concurrent.StepWorker;
@@ -41,6 +42,9 @@ public class GridService {
     private boolean lastRunWasMaze;
 
     private BooleanProperty isReady = new SimpleBooleanProperty(false);
+    // True once a pathfinding run has finished and its result is on the grid (the original's "algoDone").
+    // Gates the instant recompute while dragging start/target — no point recomputing if nothing ran yet.
+    private final BooleanProperty pathDisplayed = new SimpleBooleanProperty(false);
 
     public GridService(Grid grid, LogCleaner logCleaner) {
         this.grid = grid;
@@ -61,6 +65,7 @@ public class GridService {
 
     public void generateMaze(MazeAlgorithm algorithm) {
         lastRunWasMaze = true;
+        pathDisplayed.set(false);
         Stepper stepper;
         switch (algorithm) {
             case ALDOUS_BRODER -> {
@@ -91,6 +96,7 @@ public class GridService {
         }
 
         lastRunWasMaze = false;
+        pathDisplayed.set(false);
         switch (pathAlgorithm) {
             case A_STAR -> {
                 grid.clear(false, false, false);
@@ -100,6 +106,39 @@ public class GridService {
                         LaunchAnimationSpeed.SHORTEST_PATH.getInterval());
             }
             default -> throw new UnsupportedAlgorithmException("Unsupported algorithm: " + pathAlgorithm);
+        }
+
+        // Mark the result "displayed" once this run finishes (one-shot), so dragging start/target after
+        // it can recompute instantly.
+        isReady.addListener(new javafx.beans.value.ChangeListener<>() {
+            @Override
+            public void changed(javafx.beans.value.ObservableValue<? extends Boolean> obs, Boolean was, Boolean done) {
+                if (done) {
+                    pathDisplayed.set(true);
+                    isReady.removeListener(this);
+                }
+            }
+        });
+    }
+
+    public boolean isPathDisplayed() {
+        return pathDisplayed.get();
+    }
+
+    /**
+     * Re-runs the pathfinder with the given start/target and paints the result instantly — no step
+     * animation, no travelling arrow. Used while dragging a start/target node so the visited cells and
+     * shortest path follow the cursor live (matching the original). No-op until a path has been run.
+     */
+    public void recomputeInstant(Location start, Location target) {
+        if (!pathDisplayed.get() || !isReady() || pathAlgorithm != PathFindingAlgorithm.A_STAR) {
+            return;
+        }
+        grid.clear(false, false, false);   // clear previous visited/path, keep walls/start/target
+        GridStepRenderer renderer = new GridStepRenderer(grid, true);
+        Stepper stepper = new AStarStepper(GridSnapshot.of(grid, start, target));
+        while (stepper.hasNext()) {
+            renderer.accept(stepper.next());
         }
     }
 
@@ -194,6 +233,7 @@ public class GridService {
 
     private void clear(boolean reset, boolean removeWalls) {
         cancelRunningWorkers();
+        pathDisplayed.set(false);
 
         if (grid != null) {
             grid.setDefaultFlag(NONE);

--- a/src/main/java/com/mahefa/pathfindingfx/service/GridService.java
+++ b/src/main/java/com/mahefa/pathfindingfx/service/GridService.java
@@ -134,7 +134,7 @@ public class GridService {
         if (!pathDisplayed.get() || !isReady() || pathAlgorithm != PathFindingAlgorithm.A_STAR) {
             return;
         }
-        grid.clear(false, false, false);   // clear previous visited/path, keep walls/start/target
+        grid.clearSearchFlags();   // clear only the previous result; don't touch walls/icons/styles
         GridStepRenderer renderer = new GridStepRenderer(grid, true);
         Stepper stepper = new AStarStepper(GridSnapshot.of(grid, start, target));
         while (stepper.hasNext()) {

--- a/src/main/java/com/mahefa/pathfindingfx/service/concurrent/GridSnapshot.java
+++ b/src/main/java/com/mahefa/pathfindingfx/service/concurrent/GridSnapshot.java
@@ -1,6 +1,7 @@
 package com.mahefa.pathfindingfx.service.concurrent;
 
 import com.mahefa.pathfindingfx.algorithm.grid.GridModel;
+import com.mahefa.pathfindingfx.domain.Location;
 import com.mahefa.pathfindingfx.ui.component.Cell;
 import com.mahefa.pathfindingfx.ui.component.Grid;
 
@@ -16,6 +17,14 @@ public final class GridSnapshot {
     }
 
     public static GridModel of(Grid grid) {
+        return of(grid, grid.getStartCell().getLocation(), grid.getTargetCell().getLocation());
+    }
+
+    /**
+     * Snapshot with explicit start/target locations — used to preview the path while a start/target node
+     * is being dragged, before the move is committed to the grid.
+     */
+    public static GridModel of(Grid grid, Location start, Location target) {
         int rows = grid.getRowLen();
         int cols = grid.getColLen();
         boolean[][] wall = new boolean[rows][cols];
@@ -29,7 +38,6 @@ public final class GridSnapshot {
             }
         }
 
-        return new GridModel(rows, cols, wall, weight,
-                grid.getStartCell().getLocation(), grid.getTargetCell().getLocation());
+        return new GridModel(rows, cols, wall, weight, start, target);
     }
 }

--- a/src/main/java/com/mahefa/pathfindingfx/ui/animation/NodeAnimations.java
+++ b/src/main/java/com/mahefa/pathfindingfx/ui/animation/NodeAnimations.java
@@ -90,12 +90,19 @@ public final class NodeAnimations {
         play(node, null, timeline);
     }
 
+    /** Style class that keeps a :visited cell transparent while its reveal tile plays (see cell.scss). */
+    private static final String REVEALING_CLASS = "revealing";
+
     /**
      * Visited-cell reveal (port of the web {@code visitedAnimation}): a scale pulse plus a background
-     * morph dark-blue → blue → green → cyan, ending filled cyan. Runs on a transient tile; the cell's
-     * final cyan fill is applied when the reveal finishes. 1.5s, ease-out.
+     * morph dark-blue → blue → green → cyan. Runs on a transient tile. The cell keeps the "revealing"
+     * class for the duration so it stays transparent (the tile does the fill, growing "from nothing");
+     * on finish the class is dropped and the CSS {@code :visited} cyan takes over. 1.5s, ease-out.
      */
     public static void visited(Pane cell) {
+        if (!cell.getStyleClass().contains(REVEALING_CLASS)) {
+            cell.getStyleClass().add(REVEALING_CLASS);
+        }
         Region tile = overlayTile(cell);
         Timeline timeline = new Timeline(
                 new KeyFrame(Duration.ZERO,
@@ -113,20 +120,22 @@ public final class NodeAnimations {
                         new KeyValue(tile.scaleYProperty(), 1.0, Interpolator.EASE_OUT),
                         new KeyValue(tile.backgroundProperty(), fill(VISITED_END, 0), Interpolator.EASE_OUT))
         );
-        // Persist the final cyan on the cell so it stays filled once the transient tile is removed.
-        timeline.setOnFinished(e -> cell.setBackground(fill(VISITED_END, 0)));
+        // Reveal done: drop "revealing" so the CSS :visited cyan shows (the tile is removed by play()).
+        timeline.setOnFinished(e -> cell.getStyleClass().remove(REVEALING_CLASS));
         play(cell, tile, timeline);
     }
 
     /**
-     * Visited end-state with no reveal: fills the cell cyan immediately. Used for the instant recompute
-     * while dragging start/target, where the 1.5s pulse would be unusable.
+     * Visited end-state with no reveal: the cyan comes from the CSS {@code :visited} rule, so we just
+     * stop any running reveal and clear leftover transforms. Used for the instant recompute while
+     * dragging start/target, where the 1.5s pulse would be unusable.
      */
     public static void visitedInstant(Region cell) {
         stopRunning(cell);
+        cell.getStyleClass().remove(REVEALING_CLASS);
         cell.setScaleX(1);
         cell.setScaleY(1);
-        cell.setBackground(fill(VISITED_END, 0));
+        cell.setBackground(null);   // let the CSS :visited cyan show through
     }
 
     /**
@@ -136,6 +145,7 @@ public final class NodeAnimations {
      */
     public static void shortestPath(Pane cell) {
         stopRunning(cell);
+        cell.getStyleClass().remove(REVEALING_CLASS);
         cell.setBackground(null);
         cell.setBorder(null);
         cell.setScaleX(1);
@@ -149,6 +159,7 @@ public final class NodeAnimations {
      */
     public static void reset(Pane cell) {
         stopRunning(cell);
+        cell.getStyleClass().remove(REVEALING_CLASS);
         cell.setBackground(null);
         cell.setBorder(null);
         cell.setScaleX(1);

--- a/src/main/java/com/mahefa/pathfindingfx/ui/animation/NodeAnimations.java
+++ b/src/main/java/com/mahefa/pathfindingfx/ui/animation/NodeAnimations.java
@@ -40,6 +40,7 @@ public final class NodeAnimations {
     private static final String RUNNING_KEY = "pfx.runningReveal";
 
     private static final Color VISITED_END = Color.rgb(0, 190, 218, 0.75);   // -visited-color
+    private static final Color PATH_COLOR = Color.rgb(255, 254, 106);        // -shortest-path-color
 
     private NodeAnimations() {
     }
@@ -122,6 +123,30 @@ public final class NodeAnimations {
         );
         // Reveal done: drop "revealing" so the CSS :visited cyan shows (the tile is removed by play()).
         timeline.setOnFinished(e -> cell.getStyleClass().remove(REVEALING_CLASS));
+        play(cell, tile, timeline);
+    }
+
+    /**
+     * Shortest-path endpoint reveal, played when a dragged start/target is dropped: a tile grows from a
+     * rounded square to a full yellow square (scale pulse + corner morph). The cell's persistent yellow
+     * comes from CSS {@code :shortest-path}; the tile is removed on finish.
+     */
+    public static void pathReveal(Pane cell) {
+        Region tile = overlayTile(cell);
+        Timeline timeline = new Timeline(
+                new KeyFrame(Duration.ZERO,
+                        new KeyValue(tile.scaleXProperty(), 0.3, Interpolator.EASE_OUT),
+                        new KeyValue(tile.scaleYProperty(), 0.3, Interpolator.EASE_OUT),
+                        new KeyValue(tile.backgroundProperty(), fill(PATH_COLOR, 100), Interpolator.EASE_OUT)),
+                new KeyFrame(Duration.seconds(0.75),
+                        new KeyValue(tile.scaleXProperty(), 1.2, Interpolator.EASE_OUT),
+                        new KeyValue(tile.scaleYProperty(), 1.2, Interpolator.EASE_OUT),
+                        new KeyValue(tile.backgroundProperty(), fill(PATH_COLOR, 0), Interpolator.EASE_OUT)),
+                new KeyFrame(Duration.seconds(1.5),
+                        new KeyValue(tile.scaleXProperty(), 1.0, Interpolator.EASE_OUT),
+                        new KeyValue(tile.scaleYProperty(), 1.0, Interpolator.EASE_OUT),
+                        new KeyValue(tile.backgroundProperty(), fill(PATH_COLOR, 0), Interpolator.EASE_OUT))
+        );
         play(cell, tile, timeline);
     }
 

--- a/src/main/java/com/mahefa/pathfindingfx/ui/animation/NodeAnimations.java
+++ b/src/main/java/com/mahefa/pathfindingfx/ui/animation/NodeAnimations.java
@@ -119,6 +119,17 @@ public final class NodeAnimations {
     }
 
     /**
+     * Visited end-state with no reveal: fills the cell cyan immediately. Used for the instant recompute
+     * while dragging start/target, where the 1.5s pulse would be unusable.
+     */
+    public static void visitedInstant(Region cell) {
+        stopRunning(cell);
+        cell.setScaleX(1);
+        cell.setScaleY(1);
+        cell.setBackground(fill(VISITED_END, 0));
+    }
+
+    /**
      * Shortest-path cell: colours to yellow via CSS ({@code .cell:shortest-path}). The pop lives on the
      * arrow ({@link #pathPop}), not the cell, so the cell — and its gridline border — never scales.
      * This just stops any running visited reveal and drops its inline fill/scale so the CSS shows through.

--- a/src/main/java/com/mahefa/pathfindingfx/ui/component/Grid.java
+++ b/src/main/java/com/mahefa/pathfindingfx/ui/component/Grid.java
@@ -186,5 +186,22 @@ public class Grid {
         ImageView imageView = (ImageView) getTargetCell().getChildren().get(0);
         imageView.setImage(new Image("/icons/circle.png"));
     }
+
+    /**
+     * Clears only the search result — CURRENT/VISITED/SHORTEST_PATH flags reset to NONE — leaving walls,
+     * weights, node positions, icons and styles untouched. Used by the instant recompute while dragging
+     * start/target, which repaints many times per second and must not churn the special-node icons.
+     */
+    public void clearSearchFlags() {
+        for (int r = 0; r < rowLen; r++) {
+            for (int c = 0; c < colLen; c++) {
+                Cell cell = getCellAt(r, c);
+                Flag flag = cell.getFlag();
+                if (flag == CURRENT || flag == VISITED || flag == SHORTEST_PATH_NODE) {
+                    cell.resetFlag(NONE);
+                }
+            }
+        }
+    }
 }
 

--- a/src/main/java/com/mahefa/pathfindingfx/ui/component/GridStepRenderer.java
+++ b/src/main/java/com/mahefa/pathfindingfx/ui/component/GridStepRenderer.java
@@ -49,15 +49,14 @@ public final class GridStepRenderer implements Consumer<Step> {
         Cell cell = grid.getCellAt(location.getRow(), location.getCol());
 
         if (arrowless) {
-            // Instant recompute: just colour the cell to its final state, no arrow. Leave the special
-            // start/target cells untouched so they keep their identity.
-            if (!cell.isSpecialNode()) {
-                switch (step.type()) {
-                    case CURRENT, VISITED -> cell.setFlag(Flag.VISITED);
-                    case OPEN -> cell.setFlag(Flag.NONE);
-                    case WALL -> cell.setFlag(Flag.WALL_NODE);
-                    case PATH -> cell.setFlag(Flag.SHORTEST_PATH_NODE);
-                }
+            // Instant recompute: colour cells straight to their final state, no arrow. Path cells —
+            // including the start/target endpoints — turn yellow so an endpoint is never left blank; the
+            // endpoints keep their icon on top. Visited/wall only apply to plain cells.
+            switch (step.type()) {
+                case PATH -> cell.setFlag(Flag.SHORTEST_PATH_NODE);
+                case CURRENT, VISITED -> { if (!cell.isSpecialNode()) cell.setFlag(Flag.VISITED); }
+                case OPEN -> { if (!cell.isSpecialNode()) cell.setFlag(Flag.NONE); }
+                case WALL -> { if (!cell.isSpecialNode()) cell.setFlag(Flag.WALL_NODE); }
             }
             return;
         }

--- a/src/main/java/com/mahefa/pathfindingfx/ui/component/GridStepRenderer.java
+++ b/src/main/java/com/mahefa/pathfindingfx/ui/component/GridStepRenderer.java
@@ -26,18 +26,41 @@ public final class GridStepRenderer implements Consumer<Step> {
 
     private final Grid grid;
 
+    // When true, render the final state only — no travelling arrow, and CURRENT collapses to VISITED.
+    // Used for the instant recompute while dragging start/target (see GridService.recomputeInstant).
+    private final boolean arrowless;
+
     // PATH ("drawback") state: one arrow that walks the path to the target.
     private ImageView arrow;
     private Cell priorPathCell;
 
     public GridStepRenderer(Grid grid) {
+        this(grid, false);
+    }
+
+    public GridStepRenderer(Grid grid, boolean arrowless) {
         this.grid = grid;
+        this.arrowless = arrowless;
     }
 
     @Override
     public void accept(Step step) {
         Location location = step.location();
         Cell cell = grid.getCellAt(location.getRow(), location.getCol());
+
+        if (arrowless) {
+            // Instant recompute: just colour the cell to its final state, no arrow. Leave the special
+            // start/target cells untouched so they keep their identity.
+            if (!cell.isSpecialNode()) {
+                switch (step.type()) {
+                    case CURRENT, VISITED -> cell.setFlag(Flag.VISITED);
+                    case OPEN -> cell.setFlag(Flag.NONE);
+                    case WALL -> cell.setFlag(Flag.WALL_NODE);
+                    case PATH -> cell.setFlag(Flag.SHORTEST_PATH_NODE);
+                }
+            }
+            return;
+        }
 
         switch (step.type()) {
             case CURRENT -> cell.setFlag(Flag.CURRENT);

--- a/src/main/java/com/mahefa/pathfindingfx/ui/controller/MainWindowController.java
+++ b/src/main/java/com/mahefa/pathfindingfx/ui/controller/MainWindowController.java
@@ -50,6 +50,11 @@ public class MainWindowController {
     private Button btnPlay;
     public GridService gridService;
 
+    // Live-drag path recompute: suppress the reveal animations during an instant repaint, and remember
+    // the last previewed cell so we only recompute when the dragged node actually changes cell.
+    private boolean suppressReveal = false;
+    private Cell lastPreviewCell;
+
     public ObjectProperty<AnimationSpeed> currentSpeed = new SimpleObjectProperty<>();
 
     @FXML
@@ -230,7 +235,7 @@ public class MainWindowController {
     }
 
     private void addCellEvent(Cell cell) {
-        CellEventHandler cellEventHandler = new CellEventHandler();
+        CellEventHandler cellEventHandler = new CellEventHandler(this::previewPathDuringDrag, this::finalizePathAfterDrag);
 
 //        cell.setOnMouseClicked(cellEventHandler::handle);
         cell.setOnMousePressed(cellEventHandler::handle);
@@ -256,11 +261,42 @@ public class MainWindowController {
         cell.flagProperty().addListener((observable, oldValue, newValue) -> {
             switch (newValue) {
                 case WALL_NODE -> NodeAnimations.pop(cell);
-                case VISITED -> NodeAnimations.visited(cell);
+                // During a live drag recompute we skip the 1.5s pulse and fill the visited cell instantly.
+                case VISITED -> { if (suppressReveal) NodeAnimations.visitedInstant(cell); else NodeAnimations.visited(cell); }
                 case SHORTEST_PATH_NODE -> NodeAnimations.shortestPath(cell);
                 default -> NodeAnimations.reset(cell);
             }
         });
+    }
+
+    /**
+     * Live path preview while dragging a start/target node (matches the original): recompute and repaint
+     * the visited cells + shortest path instantly as the cursor moves, without the reveal animations.
+     * Only active once a path has been run ({@code pathDisplayed}); throttled to actual cell changes.
+     */
+    private void previewPathDuringDrag(NodeType draggedType, Cell hovered) {
+        if (gridService == null || !gridService.isPathDisplayed() || hovered == lastPreviewCell) {
+            return;
+        }
+        if (hovered.isSpecialNode() || hovered.getFlag() == Flag.WALL_NODE) {
+            return;
+        }
+        lastPreviewCell = hovered;
+        recomputeInstant(draggedType, hovered.getLocation());
+    }
+
+    // Recompute with the dragged endpoint at `dragged` (the other endpoint stays where the grid has it),
+    // suppressing the reveal animations so the repaint is instant.
+    private void recomputeInstant(NodeType draggedType, Location dragged) {
+        Grid grid = gridService.getGrid();
+        Location start = (draggedType == NodeType.START) ? dragged : grid.getStartCell().getLocation();
+        Location target = (draggedType == NodeType.TARGET) ? dragged : grid.getTargetCell().getLocation();
+        suppressReveal = true;
+        try {
+            gridService.recomputeInstant(start, target);
+        } finally {
+            suppressReveal = false;
+        }
     }
 
     private void switchNodeType(Cell newCell, Cell currentCell) {
@@ -279,6 +315,25 @@ public class MainWindowController {
         newCell.getChildren().add(currentImageView);
 
         NodeAnimations.popIcon(currentImageView);
+    }
+
+    /**
+     * Called when a start/target drag ends (drop). Repaints the path instantly for the final, committed
+     * start/target positions — this also corrects the last live preview if the drop was invalid (dropped
+     * on another node) and the node snapped back.
+     */
+    private void finalizePathAfterDrag() {
+        lastPreviewCell = null;
+        if (gridService == null || !gridService.isPathDisplayed()) {
+            return;
+        }
+        Grid grid = gridService.getGrid();
+        suppressReveal = true;
+        try {
+            gridService.recomputeInstant(grid.getStartCell().getLocation(), grid.getTargetCell().getLocation());
+        } finally {
+            suppressReveal = false;
+        }
     }
 
     private void updateSpeed(Menu parent, MenuItem currentMenuItem) {

--- a/src/main/java/com/mahefa/pathfindingfx/ui/controller/MainWindowController.java
+++ b/src/main/java/com/mahefa/pathfindingfx/ui/controller/MainWindowController.java
@@ -54,6 +54,7 @@ public class MainWindowController {
     // the last previewed cell so we only recompute when the dragged node actually changes cell.
     private boolean suppressReveal = false;
     private Cell lastPreviewCell;
+    private Cell droppedNode;
 
     public ObjectProperty<AnimationSpeed> currentSpeed = new SimpleObjectProperty<>();
 
@@ -315,15 +316,20 @@ public class MainWindowController {
         newCell.getChildren().add(currentImageView);
 
         NodeAnimations.popIcon(currentImageView);
+
+        // Remember where the node landed so the drop finalize can play its reveal there.
+        droppedNode = newCell;
     }
 
     /**
      * Called when a start/target drag ends (drop). Repaints the path instantly for the final, committed
      * start/target positions — this also corrects the last live preview if the drop was invalid (dropped
-     * on another node) and the node snapped back.
+     * on another node) and the node snapped back. The dropped endpoint then plays its reveal.
      */
     private void finalizePathAfterDrag() {
         lastPreviewCell = null;
+        Cell dropped = droppedNode;
+        droppedNode = null;
         if (gridService == null || !gridService.isPathDisplayed()) {
             return;
         }
@@ -333,6 +339,10 @@ public class MainWindowController {
             gridService.recomputeInstant(grid.getStartCell().getLocation(), grid.getTargetCell().getLocation());
         } finally {
             suppressReveal = false;
+        }
+        // The dropped endpoint reveals from a rounded square to a full yellow square (matches the original).
+        if (dropped != null && dropped.getFlag() == Flag.SHORTEST_PATH_NODE) {
+            NodeAnimations.pathReveal(dropped);
         }
     }
 

--- a/src/main/java/com/mahefa/pathfindingfx/ui/event/CellEventHandler.java
+++ b/src/main/java/com/mahefa/pathfindingfx/ui/event/CellEventHandler.java
@@ -10,11 +10,28 @@ import com.mahefa.pathfindingfx.domain.enumerator.NodeType;
 import com.mahefa.pathfindingfx.ui.animation.NodeAnimations;
 import com.mahefa.pathfindingfx.ui.component.Cell;
 
+import java.util.function.BiConsumer;
+
 import static com.mahefa.pathfindingfx.ui.style.CellStyle.Flag;
 
 public class CellEventHandler implements EventHandler<Event> {
 
     private boolean isMousePressed = false;
+
+    // Notified on each DRAG_OVER while a start/target node is being dragged: (dragged node type, cell
+    // under the cursor). Lets the controller recompute the path live as the node moves.
+    private final BiConsumer<NodeType, Cell> onDragOverSpecial;
+    // Notified when a start/target drag ends (drop), so the controller can repaint for the final position.
+    private final Runnable onDragFinished;
+
+    public CellEventHandler() {
+        this(null, null);
+    }
+
+    public CellEventHandler(BiConsumer<NodeType, Cell> onDragOverSpecial, Runnable onDragFinished) {
+        this.onDragOverSpecial = onDragOverSpecial;
+        this.onDragFinished = onDragFinished;
+    }
 
     @Override
     public void handle(Event event) {
@@ -93,6 +110,12 @@ public class CellEventHandler implements EventHandler<Event> {
 
         if (sourceNode instanceof Pane) {
             event.acceptTransferModes(TransferMode.MOVE);
+
+            // Live path preview: while a start/target node is dragged, tell the controller which cell the
+            // cursor is over so it can recompute instantly. The node itself only moves on drop.
+            if (sourceNode.isSpecialNode() && onDragOverSpecial != null && event.getSource() instanceof Cell hovered) {
+                onDragOverSpecial.accept(sourceNode.getNodeType(), hovered);
+            }
         }
 
         event.consume();
@@ -113,6 +136,11 @@ public class CellEventHandler implements EventHandler<Event> {
             } else {
                 targetNode.setNodeType(sourceNode.getNodeType());
             }
+        }
+
+        // Repaint the path for the committed position (also clears a stale live preview on an invalid drop).
+        if (onDragFinished != null) {
+            onDragFinished.run();
         }
 
         event.setDropCompleted(true);

--- a/src/main/resources/sass/cell.scss
+++ b/src/main/resources/sass/cell.scss
@@ -55,9 +55,17 @@
   }
 
   &:visited {
-    // Background is morphed to cyan by NodeAnimations.visited() (native Timeline). Keep the light grid
-    // border: a cell's top/left edge is the shared gridline for its neighbours, so dropping it here
-    // would leave gaps in the grid as cells reveal.
+    // Cyan fill comes from CSS so it persists on its own — needed by the instant recompute while
+    // dragging (a one-shot programmatic fill would be wiped by the next CSS pass). Keep the light grid
+    // border: a cell's top/left edge is the shared gridline for its neighbours.
+    -fx-background-color: -visited-color;
     -fx-border-color: -grid-border-color;
+  }
+
+  // During the animated reveal the tile does the fill, so keep the cell itself transparent — this lets
+  // the reveal grow "from nothing" instead of flashing the full cyan. NodeAnimations.visited() adds the
+  // "revealing" class for the duration and removes it on finish, leaving the :visited cyan above.
+  &.revealing:visited {
+    -fx-background-color: transparent;
   }
 }


### PR DESCRIPTION
## Feature
Matches the original: once a pathfinding run has finished, **dragging the start or target node recomputes the visited cells + shortest path live** as the node moves over the grid (and on drop). No re-clicking Visualize needed.

## Behaviour
- Only active after a run has completed (`pathDisplayed`, the original's `algoDone`). Cleared by any Clear action or maze generation.
- The recompute is **instant** — no step-by-step search animation and no travelling arrow (those would be unusable while dragging). The search runs synchronously and cells are painted straight to their final colours (visited → cyan, path → yellow).
- Works continuously on every cell the node passes over (throttled to actual cell changes), and finalizes on drop. An invalid drop (onto another node) snaps back and repaints for the real position.

## How
- **GridService**: `pathDisplayed` flag + `recomputeInstant(start, target)` — reruns A* with the dragged endpoint overridden and paints instantly.
- **GridStepRenderer**: new *arrowless* mode — final-state colours only, no arrow, `CURRENT`→`VISITED`, special nodes left untouched.
- **GridSnapshot.of(grid, start, target)**: snapshot with explicit endpoints (preview before the move commits).
- **NodeAnimations.visitedInstant**: cyan fill, no pulse.
- **CellEventHandler**: `DRAG_OVER` preview callback + drop finalize callback.
- **MainWindowController**: suppresses reveal animations during the instant repaint; wires preview + finalize.

## Testing
- `mvn test` green (5); `mvn compile` green.
- **Needs manual verification** (I can't drive the JavaFX GUI here): run A*, then drag start/target around — path/visited should follow live and instantly; drag before running should just move the node; Clear/maze should stop the live recompute.
- Perf note to watch: each cell change reruns A* + repaints; on very large grids this could feel heavy. Easy to optimize later if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)